### PR TITLE
#16 ADD support for `format_status` in gen_event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,18 @@
 name: "[Hex] Publish"
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: read
-  id-token: write
-  pages: write
 
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -34,6 +35,9 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     needs: build-docs
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -44,6 +48,10 @@ jobs:
 
   publish-to-hex:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ gleam add eparch
 
 ### Usage
 
-See the [Quick Start guide](https://hexdocs.pm/eparch/quick_start.html) for full walkthroughs, or run some of the example projects that live in the [`examples/`](https://hexdocs.pm/eparch/readme.html) directory.
+See the [Quick Start guide](https://hexdocs.pm/eparch/docs/quick_start.html) for full walkthroughs, or run some of the example projects that live in the [`examples/`](https://hexdocs.pm/eparch/examples/readme.html) directory.
 
 ## Development
 

--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -39,10 +39,6 @@
 import gleam/erlang/process.{type Pid}
 import gleam/option.{type Option, None, Some}
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
 /// The result of a handler processing an event.
 ///
 /// Return `Continue(new_state)` to keep the handler alive with updated state,
@@ -77,13 +73,14 @@ pub type RemoveError {
 /// A builder for configuring a handler before registering it with a manager.
 ///
 /// Create one with `new_handler/2` and optionally extend it with
-/// `on_terminate/2`.
+/// `on_terminate/2` and `on_format_status/2`.
 ///
 pub opaque type Handler(state, event) {
   Handler(
     init_state: state,
     on_event: fn(event, state) -> EventStep(state),
     on_terminate: Option(fn(state) -> Nil),
+    on_format_status: Option(fn(state) -> String),
   )
 }
 
@@ -126,7 +123,12 @@ pub fn new_handler(
   initial_state initial_state: state,
   on_event handler: fn(event, state) -> EventStep(state),
 ) -> Handler(state, event) {
-  Handler(init_state: initial_state, on_event: handler, on_terminate: None)
+  Handler(
+    init_state: initial_state,
+    on_event: handler,
+    on_terminate: None,
+    on_format_status: None,
+  )
 }
 
 /// Attach a cleanup function called when the handler is removed or the manager
@@ -144,6 +146,29 @@ pub fn on_terminate(
   cleanup: fn(state) -> Nil,
 ) -> Handler(state, event) {
   Handler(..handler, on_terminate: Some(cleanup))
+}
+
+/// Provide a function to format this handler's state for OTP status reports.
+///
+/// When set, the returned string is used in place of the raw state in
+/// `sys:get_status/1` output and SASL crash reports. Useful for hiding
+/// secrets, summarising large data structures, or presenting a domain-friendly
+/// view. Since OTP 25.0.
+///
+/// ## Example
+///
+/// ```gleam
+/// event_manager.new_handler(connection, on_event)
+/// |> event_manager.on_format_status(fn(conn) {
+///   "Conn(id=" <> conn.id <> ")"
+/// })
+/// ```
+///
+pub fn on_format_status(
+  handler: Handler(state, event),
+  formatter: fn(state) -> String,
+) -> Handler(state, event) {
+  Handler(..handler, on_format_status: Some(formatter))
 }
 
 // Manager lifecycle

--- a/src/event_manager_ffi.erl
+++ b/src/event_manager_ffi.erl
@@ -37,7 +37,8 @@ every installed instance distinguishable.
     handle_info/2,
     handle_call/2,
     terminate/2,
-    code_change/3
+    code_change/3,
+    format_status/1
 ]).
 
 %%%===================================================================
@@ -51,7 +52,9 @@ every installed instance distinguishable.
     % fn(event, state) -> EventStep
     on_event,
     % none | {some, fn(state) -> nil}
-    on_terminate
+    on_terminate,
+    % none | {some, fn(state) -> binary()}
+    on_format_status
 }).
 
 %%%===================================================================
@@ -187,19 +190,20 @@ do_sync_notify(Pid, Event) ->
 Initialise a handler instance from the Gleam Handler builder record.
 
 The Gleam `Handler(state, event)` opaque type is represented at the Erlang
-level as a 4-tuple:
+level as a 5-tuple:
 
-    {handler, InitState, OnEvent, OnTerminate}
+    {handler, InitState, OnEvent, OnTerminate, OnFormatStatus}
 
 We unpack it here and store the fields alongside the unique Ref in a
 `#gleam_handler{}` record.
 """.
-init({{handler, InitState, OnEvent, OnTerminate}, Ref}) ->
+init({{handler, InitState, OnEvent, OnTerminate, OnFormatStatus}, Ref}) ->
     State = #gleam_handler{
         ref = Ref,
         gleam_state = InitState,
         on_event = OnEvent,
-        on_terminate = OnTerminate
+        on_terminate = OnTerminate,
+        on_format_status = OnFormatStatus
     },
     {ok, State}.
 
@@ -261,3 +265,27 @@ Hot-code upgrade support (pass-through).
 """.
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+-doc """
+Format the handler state for `sys:get_status/1` and SASL crash reports.
+
+OTP 25+ semantics: receives a status map containing `state` (the handler's
+internal record) plus optional `message`, `reason`, and `log` keys. Returns
+the same map, optionally with `state` replaced by the user-supplied
+formatter's output. When no `on_format_status` was registered, the map is
+returned unchanged.
+""".
+format_status(
+    #{
+        state := #gleam_handler{
+            on_format_status = OnFormatStatus,
+            gleam_state = GleamState
+        }
+    } = Status
+) ->
+    case OnFormatStatus of
+        none ->
+            Status;
+        {some, Fun} ->
+            Status#{state => Fun(GleamState)}
+    end.

--- a/test/event_manager_test.gleam
+++ b/test/event_manager_test.gleam
@@ -6,10 +6,15 @@
 ////
 
 import eparch/event_manager
+import gleam/dynamic.{type Dynamic}
 import gleam/erlang/process
+import gleam/int
 import gleam/list
 import gleam/string
 import gleeunit/should
+
+@external(erlang, "sys", "get_status")
+fn sys_get_status(pid: process.Pid) -> Dynamic
 
 // ---------------------------------------------------------------------------
 // START / STOP
@@ -257,6 +262,48 @@ pub fn on_terminate_called_when_handler_removed_test() {
 
   let assert Ok(msg) = process.receive(reply_sub, 1000)
   msg |> should.equal("terminated")
+
+  event_manager.stop(mgr)
+}
+
+// ---------------------------------------------------------------------------
+// ON FORMAT STATUS
+//
+// When on_format_status is set, sys:get_status/1 reflects the formatted
+// state. When unset, the call still succeeds (raw state passes through).
+// ---------------------------------------------------------------------------
+
+pub fn on_format_status_overrides_state_in_status_report_test() {
+  let assert Ok(mgr) = event_manager.start()
+
+  let h =
+    event_manager.new_handler(42, fn(_event, state) {
+      event_manager.Continue(state)
+    })
+    |> event_manager.on_format_status(fn(n) { "FORMATTED:" <> int.to_string(n) })
+
+  let assert Ok(_ref) = event_manager.add_handler(mgr, h)
+
+  let status = sys_get_status(event_manager.manager_pid(mgr))
+  string.inspect(status)
+  |> string.contains("FORMATTED:42")
+  |> should.equal(True)
+
+  event_manager.stop(mgr)
+}
+
+pub fn handler_without_format_status_still_appears_in_status_test() {
+  let assert Ok(mgr) = event_manager.start()
+
+  let h =
+    event_manager.new_handler(Nil, fn(_event, state) {
+      event_manager.Continue(state)
+    })
+
+  let assert Ok(_ref) = event_manager.add_handler(mgr, h)
+
+  // Should not crash; sys:get_status returns a non-empty term.
+  let _ = sys_get_status(event_manager.manager_pid(mgr))
 
   event_manager.stop(mgr)
 }


### PR DESCRIPTION
## Description

Adds support for `format_status` in `gen_event`.

## Related Issue

- Closes #16 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / cleanup

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `gleam format` run
