### PR TITLE
#15 ADD `start_monitor/{0,1,2}` support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
+dotenv_if_exists
 use flake . --no-pure-eval

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ result
 # lockfiles drift every time the root version bumps and provide no
 # reproducibility value. Let each build regenerate them fresh.
 examples/*/manifest.toml
+
+# Extra
+.env

--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -17,26 +17,27 @@
 ////
 //// type MyEvent { LogLine(String) | Flush(process.Subject(Nil)) }
 ////
-//// let assert Ok(mgr) = event_manager.start()
-////
-//// let handler =
-////   event_manager.new_handler(0, fn(event, count) {
-////     case event {
-////       LogLine(_) -> event_manager.Continue(count + 1)
-////       Flush(reply) -> {
-////         process.send(reply, Nil)
-////         event_manager.Continue(count)
-////       }
-////     }
-////   })
-////
-//// let assert Ok(_ref) = event_manager.add_handler(mgr, handler)
-////
-//// event_manager.notify(mgr, LogLine("hello"))
-//// event_manager.sync_notify(mgr, LogLine("world"))
+//// case event_manager.start() {
+////   Ok(manager) -> {
+////     let handler =
+////       event_manager.new_handler(0, fn(event, count) {
+////         case event {
+////           LogLine(_) -> event_manager.Continue(count + 1)
+////           Flush(reply) -> {
+////             process.send(reply, Nil)
+////             event_manager.Continue(count)
+////           }
+////         }
+////       })
+////     let _ = event_manager.add_handler(manager, handler)
+////     event_manager.notify(manager, LogLine("hello"))
+////     event_manager.sync_notify(manager, LogLine("world"))
+////   }
+////   Error(_) -> Nil
+//// }
 //// ```
 
-import gleam/erlang/process.{type Pid}
+import gleam/erlang/process.{type Monitor, type Name, type Pid}
 import gleam/option.{type Option, None, Some}
 
 /// The result of a handler processing an event.
@@ -54,20 +55,92 @@ pub type EventStep(state) {
 
 /// Errors that can occur when starting an event manager.
 pub type StartError {
-  AlreadyStarted
-  StartFailed(String)
+  /// A manager with the requested registered name is already running.
+  /// The field carries the Pid of the already-running manager so callers can
+  /// reuse it or diagnose the conflict.
+  AlreadyStarted(pid: Pid)
+  /// Startup failed for another reason. `reason` is a human-readable string
+  /// produced from the raw Erlang error term.
+  StartFailed(reason: String)
+}
+
+/// A timeout: either a fixed number of milliseconds or `Infinity`.
+pub type Timeout {
+  Infinity
+  Milliseconds(ms: Int)
+}
+
+/// Process priority for `SpawnPriority`.
+pub type Priority {
+  PriorityLow
+  PriorityNormal
+  PriorityHigh
+  PriorityMax
+}
+
+/// Message queue storage mode for `SpawnMessageQueueData`.
+pub type MessageQueueMode {
+  OnHeap
+  OffHeap
+}
+
+/// Flags for the `debug` option of `StartOptions`.
+pub type DebugFlag {
+  DebugTrace
+  DebugLog
+  DebugStatistics
+  DebugLogToFile(file_name: String)
+}
+
+/// Flags for the `spawn_options` option of `StartOptions`. Subset of
+/// `erlang:spawn_opt/2`'s options that are meaningful for a long-running
+/// server process. `link` and `monitor` are intentionally omitted — the
+/// manager is always linked (and optionally monitored) by the `start` /
+/// `start_monitor` entry points themselves.
+pub type SpawnOption {
+  SpawnPriority(level: Priority)
+  SpawnFullsweepAfter(count: Int)
+  SpawnMinHeapSize(size: Int)
+  SpawnMinBinVheapSize(size: Int)
+  SpawnMaxHeapSize(size: Int)
+  SpawnMessageQueueData(mode: MessageQueueMode)
+}
+
+/// Options for `start_monitor`. Build a value with `new_start_options()` and
+/// extend it using the `with_*` setter functions.
+///
+pub opaque type StartOptions(event) {
+  StartOptions(
+    name: Option(Name(event)),
+    timeout: Timeout,
+    hibernate_after: Timeout,
+    debug: List(DebugFlag),
+    spawn_options: List(SpawnOption),
+  )
+}
+
+/// Data returned when a manager is started with `start_monitor`.
+pub type MonitoredManager(event) {
+  MonitoredManager(manager: Manager(event), monitor: Monitor)
 }
 
 /// Errors that can occur when adding a handler.
 pub type AddError {
-  HandlerAlreadyExists
-  InitFailed(String)
+  /// A handler with the same identity is already registered. The field
+  /// carries the `HandlerRef` that caused the collision.
+  HandlerAlreadyExists(handler_ref: HandlerRef)
+  /// The handler's initialisation failed. `reason` is a human-readable
+  /// string produced from the raw Erlang error term.
+  InitFailed(reason: String)
 }
 
 /// Errors that can occur when removing a handler.
 pub type RemoveError {
-  HandlerNotFound
-  RemoveFailed(String)
+  /// No handler with the given ref is currently registered. The field
+  /// carries the `HandlerRef` the caller supplied.
+  HandlerNotFound(handler_ref: HandlerRef)
+  /// Removal failed for another reason.
+  RemoveFailed(reason: String)
 }
 
 /// A builder for configuring a handler before registering it with a manager.
@@ -87,14 +160,15 @@ pub opaque type Handler(state, event) {
 /// An opaque reference to a specific registered handler instance.
 ///
 /// Values of this type are only ever produced by `add_handler` or
-/// `add_sup_handler`. Pass them to `remove_handler` to unregister a specific
-/// handler, or compare them with values returned by `which_handlers`.
+/// `add_supervised_handler`. Pass them to `remove_handler` to unregister a
+/// specific handler, or compare them with values returned by `which_handlers`.
 ///
 pub type HandlerRef
 
 /// An opaque reference to a running event manager process.
 ///
-/// Values of this type are only ever produced by `start`. Pass them to
+/// Values of this type are produced by `start` (directly) and `start_monitor`
+/// (as the `manager` field of the returned `MonitoredManager`). Pass them to
 /// `notify`, `sync_notify`, `add_handler`, etc.
 ///
 pub type Manager(event)
@@ -137,8 +211,8 @@ pub fn new_handler(
 /// ## Example
 ///
 /// ```gleam
-/// event_manager.new_handler(conn, on_event)
-/// |> event_manager.on_terminate(fn(conn) { db.close(conn) })
+/// event_manager.new_handler(connection, on_event)
+/// |> event_manager.on_terminate(fn(connection) { db.close(connection) })
 /// ```
 ///
 pub fn on_terminate(
@@ -159,8 +233,8 @@ pub fn on_terminate(
 ///
 /// ```gleam
 /// event_manager.new_handler(connection, on_event)
-/// |> event_manager.on_format_status(fn(conn) {
-///   "Conn(id=" <> conn.id <> ")"
+/// |> event_manager.on_format_status(fn(connection) {
+///   "Conn(id=" <> connection.id <> ")"
 /// })
 /// ```
 ///
@@ -171,13 +245,87 @@ pub fn on_format_status(
   Handler(..handler, on_format_status: Some(formatter))
 }
 
+// ---------------------------------------------------------------------------
+// StartOptions builder
+// ---------------------------------------------------------------------------
+/// Build a fresh `StartOptions` with defaults: no registered name, `Infinity`
+/// for both `timeout` and `hibernate_after`, no debug flags, no spawn options.
+///
+pub fn new_start_options() -> StartOptions(event) {
+  StartOptions(
+    name: None,
+    timeout: Infinity,
+    hibernate_after: Infinity,
+    debug: [],
+    spawn_options: [],
+  )
+}
+
+/// Register the manager under a local name. Gives callers a
+/// `process.Name(event)` they can turn into a `Subject` or look up with
+/// `process.named/1`.
+///
+pub fn with_name(
+  options: StartOptions(event),
+  name: Name(event),
+) -> StartOptions(event) {
+  StartOptions(..options, name: Some(name))
+}
+
+/// Set the initialisation timeout. Passed through to gen_event as the
+/// `{timeout, _}` option.
+///
+pub fn with_timeout(
+  options: StartOptions(event),
+  timeout: Timeout,
+) -> StartOptions(event) {
+  StartOptions(..options, timeout: timeout)
+}
+
+/// Set the idle hibernation timeout. Passed through to gen_event as the
+/// `{hibernate_after, _}` option.
+///
+pub fn with_hibernate_after(
+  options: StartOptions(event),
+  timeout: Timeout,
+) -> StartOptions(event) {
+  StartOptions(..options, hibernate_after: timeout)
+}
+
+/// Set the sys debug flags for the manager.
+///
+pub fn with_debug(
+  options: StartOptions(event),
+  flags: List(DebugFlag),
+) -> StartOptions(event) {
+  StartOptions(..options, debug: flags)
+}
+
+/// Set the `erlang:spawn_opt/2` options forwarded to the manager process.
+///
+pub fn with_spawn_options(
+  options: StartOptions(event),
+  spawn_options: List(SpawnOption),
+) -> StartOptions(event) {
+  StartOptions(..options, spawn_options: spawn_options)
+}
+
+// ---------------------------------------------------------------------------
 // Manager lifecycle
+// ---------------------------------------------------------------------------
+
 /// Start an event manager process linked to the caller.
 ///
 /// ## Example
 ///
 /// ```gleam
-/// let assert Ok(mgr) = event_manager.start()
+/// case event_manager.start() {
+///   Ok(manager) -> {
+///     // ... use manager ...
+///     event_manager.stop(manager)
+///   }
+///   Error(_) -> Nil
+/// }
 /// ```
 ///
 pub fn start() -> Result(Manager(event), StartError) {
@@ -186,6 +334,39 @@ pub fn start() -> Result(Manager(event), StartError) {
 
 @external(erlang, "event_manager_ffi", "do_start")
 fn do_start() -> Result(Manager(event), StartError)
+
+/// Start an event manager linked to the caller and atomically return a
+/// monitor for it.
+///
+/// Equivalent to calling `start()` followed by `process.monitor(manager_pid)`,
+/// but without the race window between the two calls. The returned
+/// `MonitoredManager` carries both the `Manager` and a `process.Monitor` you
+/// can select on. Since OTP 23.0.
+///
+/// ## Example
+///
+/// ```gleam
+/// case event_manager.start_monitor(event_manager.new_start_options()) {
+///   Ok(monitored) -> {
+///     let selector =
+///       process.new_selector()
+///       |> process.select_specific_monitor(monitored.monitor, fn(down) { down })
+///     // ... use monitored.manager, wait on `selector` for a Down message ...
+///   }
+///   Error(_) -> Nil
+/// }
+/// ```
+///
+pub fn start_monitor(
+  options: StartOptions(event),
+) -> Result(MonitoredManager(event), StartError) {
+  do_start_monitor(options)
+}
+
+@external(erlang, "event_manager_ffi", "do_start_monitor")
+fn do_start_monitor(
+  options: StartOptions(event),
+) -> Result(MonitoredManager(event), StartError)
 
 /// Stop the event manager, terminating it with reason `normal`.
 ///
@@ -201,7 +382,8 @@ fn do_stop(manager: Manager(event)) -> Nil
 
 /// Return the Pid of the event manager process.
 ///
-/// Useful for monitoring the manager with `process.monitor`.
+/// Useful for monitoring the manager with `process.monitor` when you did not
+/// start it via `start_monitor`.
 ///
 pub fn manager_pid(manager: Manager(event)) -> Pid {
   do_manager_pid(manager)
@@ -210,7 +392,10 @@ pub fn manager_pid(manager: Manager(event)) -> Pid {
 @external(erlang, "event_manager_ffi", "do_manager_pid")
 fn do_manager_pid(manager: Manager(event)) -> Pid
 
+// ---------------------------------------------------------------------------
 // Handler management
+// ---------------------------------------------------------------------------
+
 /// Register an unsupervised handler with the event manager.
 ///
 /// Returns `Ok(HandlerRef)` on success. The returned ref uniquely identifies
@@ -222,7 +407,10 @@ fn do_manager_pid(manager: Manager(event)) -> Pid
 /// ## Example
 ///
 /// ```gleam
-/// let assert Ok(ref) = event_manager.add_handler(mgr, my_handler)
+/// case event_manager.add_handler(manager, my_handler) {
+///   Ok(handler_ref) -> // use handler_ref later with remove_handler
+///   Error(_) -> Nil
+/// }
 /// ```
 ///
 pub fn add_handler(
@@ -242,15 +430,15 @@ fn do_add_handler(
 ///
 /// Like `add_handler`, but links the handler to the calling process. If the
 /// handler is removed for any reason other than a normal `remove_handler` call
-/// (e.g. it crashes or returns `Remove`), the calling process receives a
-/// message of the form:
+/// (e.g. it crashes or returns `Remove`), the calling process receives an
+/// Erlang message shaped like:
 ///
 /// ```
 /// {gen_event_EXIT, HandlerRef, Reason}
 /// ```
 ///
-/// You can receive this message using `process.selecting_anything` with a
-/// `gleam/dynamic` decoder.
+/// Receive it via `gleam/erlang/process` selectors — `process.select_other` is
+/// the catch-all hook you can use to observe raw Erlang messages.
 ///
 pub fn add_supervised_handler(
   manager: Manager(event),
@@ -271,15 +459,15 @@ fn do_add_supervised_handler(
 ///
 pub fn remove_handler(
   manager: Manager(event),
-  ref: HandlerRef,
+  handler_ref: HandlerRef,
 ) -> Result(Nil, RemoveError) {
-  do_remove_handler(manager, ref)
+  do_remove_handler(manager, handler_ref)
 }
 
 @external(erlang, "event_manager_ffi", "do_remove_handler")
 fn do_remove_handler(
   manager: Manager(event),
-  ref: HandlerRef,
+  handler_ref: HandlerRef,
 ) -> Result(Nil, RemoveError)
 
 /// Return the list of `HandlerRef`s for all currently registered handlers.
@@ -291,7 +479,10 @@ pub fn which_handlers(manager: Manager(event)) -> List(HandlerRef) {
 @external(erlang, "event_manager_ffi", "do_which_handlers")
 fn do_which_handlers(manager: Manager(event)) -> List(HandlerRef)
 
+// ---------------------------------------------------------------------------
 // Notifications
+// ---------------------------------------------------------------------------
+
 /// Asynchronously broadcast an event to all registered handlers.
 ///
 /// Returns immediately without waiting for handlers to finish processing.

--- a/src/event_manager_ffi.erl
+++ b/src/event_manager_ffi.erl
@@ -20,6 +20,7 @@ every installed instance distinguishable.
 %% Public API (called from Gleam via @external)
 -export([
     do_start/0,
+    do_start_monitor/1,
     do_stop/1,
     do_manager_pid/1,
     do_add_handler/2,
@@ -72,11 +73,86 @@ do_start() ->
     case gen_event:start_link() of
         {ok, Pid} ->
             {ok, Pid};
-        {error, {already_started, _}} ->
-            {error, already_started};
+        {error, {already_started, Pid}} ->
+            {error, {already_started, Pid}};
         {error, Reason} ->
-            {error, {start_failed, term_to_binary(Reason)}}
+            {error, {start_failed, format_reason(Reason)}}
     end.
+
+-doc """
+Start a gen_event manager with an atomic monitor (OTP 23.0+).
+
+The Gleam side passes an opaque `StartOptions` record, encoded at the Erlang
+level as:
+
+    {start_options, NameOpt, Timeout, HibernateAfter, DebugFlags, SpawnOpts}
+
+`NameOpt` is `none | {some, Name}`; `Timeout`/`HibernateAfter` are
+`infinity | {milliseconds, Ms}`; the two list fields are empty when unused.
+Returns the `MonitoredManager(manager, monitor)` 3-tuple the Gleam compiler
+expects.
+""".
+do_start_monitor({start_options, NameOpt, Timeout, HibernateAfter, DebugFlags, SpawnOpts}) ->
+    ErlangOpts = build_start_opts(Timeout, HibernateAfter, DebugFlags, SpawnOpts),
+    Result =
+        case NameOpt of
+            none ->
+                gen_event:start_monitor(ErlangOpts);
+            {some, Name} ->
+                gen_event:start_monitor({local, Name}, ErlangOpts)
+        end,
+    case Result of
+        {ok, {Pid, MonitorRef}} ->
+            {ok, {monitored_manager, Pid, MonitorRef}};
+        {error, {already_started, Pid}} ->
+            {error, {already_started, Pid}};
+        {error, Reason} ->
+            {error, {start_failed, format_reason(Reason)}}
+    end.
+
+build_start_opts(Timeout, HibernateAfter, DebugFlags, SpawnOpts) ->
+    [{timeout, timeout_to_erlang(Timeout)}, {hibernate_after, timeout_to_erlang(HibernateAfter)}] ++
+        case DebugFlags of
+            [] -> [];
+            _ -> [{debug, [debug_to_erlang(F) || F <- DebugFlags]}]
+        end ++
+        case SpawnOpts of
+            [] -> [];
+            _ -> [{spawn_opt, [spawn_opt_to_erlang(O) || O <- SpawnOpts]}]
+        end.
+
+timeout_to_erlang(infinity) -> infinity;
+timeout_to_erlang({milliseconds, Ms}) -> Ms.
+
+debug_to_erlang(debug_trace) -> trace;
+debug_to_erlang(debug_log) -> log;
+debug_to_erlang(debug_statistics) -> statistics;
+debug_to_erlang({debug_log_to_file, FileName}) -> {log_to_file, FileName}.
+
+spawn_opt_to_erlang({spawn_priority, Level}) ->
+    {priority, priority_to_erlang(Level)};
+spawn_opt_to_erlang({spawn_fullsweep_after, N}) ->
+    {fullsweep_after, N};
+spawn_opt_to_erlang({spawn_min_heap_size, N}) ->
+    {min_heap_size, N};
+spawn_opt_to_erlang({spawn_min_bin_vheap_size, N}) ->
+    {min_bin_vheap_size, N};
+spawn_opt_to_erlang({spawn_max_heap_size, N}) ->
+    {max_heap_size, N};
+spawn_opt_to_erlang({spawn_message_queue_data, Mode}) ->
+    {message_queue_data, mq_mode_to_erlang(Mode)}.
+
+%% Render an Erlang error term as a human-readable Gleam string.
+format_reason(Reason) ->
+    unicode:characters_to_binary(io_lib:format("~p", [Reason])).
+
+priority_to_erlang(priority_low) -> low;
+priority_to_erlang(priority_normal) -> normal;
+priority_to_erlang(priority_high) -> high;
+priority_to_erlang(priority_max) -> max.
+
+mq_mode_to_erlang(on_heap) -> on_heap;
+mq_mode_to_erlang(off_heap) -> off_heap.
 
 -doc """
 Stop the event manager, terminating it with reason `normal`.
@@ -109,11 +185,11 @@ do_add_handler(Pid, GleamHandler) ->
         ok ->
             {ok, HandlerId};
         {'EXIT', Reason} ->
-            {error, {init_failed, erlang:term_to_binary(Reason)}};
+            {error, {init_failed, format_reason(Reason)}};
         {error, already_started} ->
-            {error, handler_already_exists};
+            {error, {handler_already_exists, HandlerId}};
         {error, Reason} ->
-            {error, {init_failed, erlang:term_to_binary(Reason)}}
+            {error, {init_failed, format_reason(Reason)}}
     end.
 
 -doc """
@@ -130,11 +206,11 @@ do_add_sup_handler(Pid, GleamHandler) ->
         ok ->
             {ok, HandlerId};
         {'EXIT', Reason} ->
-            {error, {init_failed, erlang:term_to_binary(Reason)}};
+            {error, {init_failed, format_reason(Reason)}};
         {error, already_started} ->
-            {error, handler_already_exists};
+            {error, {handler_already_exists, HandlerId}};
         {error, Reason} ->
-            {error, {init_failed, erlang:term_to_binary(Reason)}}
+            {error, {init_failed, format_reason(Reason)}}
     end.
 
 -doc """
@@ -145,11 +221,13 @@ with reason `{stop, remove_handler}`.
 """.
 do_remove_handler(Pid, HandlerId) ->
     case gen_event:delete_handler(Pid, HandlerId, remove_handler) of
-        ok ->
-            {ok, nil};
         {error, module_not_found} ->
-            {error, handler_not_found};
-        _ ->
+            {error, {handler_not_found, HandlerId}};
+        {'EXIT', Reason} ->
+            {error, {remove_failed, format_reason(Reason)}};
+        _TerminateResult ->
+            %% Any other value is what the handler's terminate/2 returned
+            %% (which we treat as a successful removal).
             {ok, nil}
     end.
 

--- a/test/event_manager_test.gleam
+++ b/test/event_manager_test.gleam
@@ -307,3 +307,105 @@ pub fn handler_without_format_status_still_appears_in_status_test() {
 
   event_manager.stop(mgr)
 }
+
+// ---------------------------------------------------------------------------
+// START MONITOR
+//
+// start_monitor/0,1,2 (OTP 23.0+) starts the manager linked to the caller
+// and atomically returns a monitor. The monitor fires when the manager
+// exits.
+// ---------------------------------------------------------------------------
+
+type StartMonitorMsg {
+  StartMonitorPing(reply_with: process.Subject(String))
+}
+
+pub fn start_monitor_returns_manager_and_monitor_test() {
+  let assert Ok(monitored) =
+    event_manager.start_monitor(event_manager.new_start_options())
+
+  let handler =
+    event_manager.new_handler(Nil, fn(event, state) {
+      case event {
+        StartMonitorPing(reply_with: subject) -> {
+          process.send(subject, "pong")
+          event_manager.Continue(state)
+        }
+      }
+    })
+
+  let assert Ok(_ref) = event_manager.add_handler(monitored.manager, handler)
+
+  let reply_subject = process.new_subject()
+  event_manager.sync_notify(
+    monitored.manager,
+    StartMonitorPing(reply_with: reply_subject),
+  )
+
+  let assert Ok(reply) = process.receive(reply_subject, 1000)
+  reply |> should.equal("pong")
+
+  event_manager.stop(monitored.manager)
+}
+
+pub fn start_monitor_fires_monitor_on_stop_test() {
+  let assert Ok(monitored) =
+    event_manager.start_monitor(event_manager.new_start_options())
+
+  let selector =
+    process.new_selector()
+    |> process.select_specific_monitor(monitored.monitor, fn(down) { down })
+
+  event_manager.stop(monitored.manager)
+
+  let assert Ok(_down) = process.selector_receive(from: selector, within: 1000)
+}
+
+pub fn start_monitor_with_name_registers_process_test() {
+  let name = process.new_name("eparch_event_manager_test_")
+  let options =
+    event_manager.new_start_options()
+    |> event_manager.with_name(name)
+
+  let assert Ok(monitored) = event_manager.start_monitor(options)
+
+  let assert Ok(registered_pid) = process.named(name)
+  registered_pid |> should.equal(event_manager.manager_pid(monitored.manager))
+
+  let selector =
+    process.new_selector()
+    |> process.select_specific_monitor(monitored.monitor, fn(down) { down })
+
+  event_manager.stop(monitored.manager)
+
+  let assert Ok(_down) = process.selector_receive(from: selector, within: 1000)
+}
+
+pub fn start_monitor_already_started_returns_error_test() {
+  let name = process.new_name("eparch_event_manager_dup_test_")
+  let options =
+    event_manager.new_start_options()
+    |> event_manager.with_name(name)
+
+  let assert Ok(monitored) = event_manager.start_monitor(options)
+  let first_pid = event_manager.manager_pid(monitored.manager)
+
+  let assert Error(event_manager.AlreadyStarted(reported_pid)) =
+    event_manager.start_monitor(options)
+  reported_pid |> should.equal(first_pid)
+
+  event_manager.stop(monitored.manager)
+}
+
+pub fn start_monitor_accepts_option_passthrough_test() {
+  let options =
+    event_manager.new_start_options()
+    |> event_manager.with_timeout(event_manager.Milliseconds(5000))
+    |> event_manager.with_spawn_options([
+      event_manager.SpawnPriority(event_manager.PriorityNormal),
+    ])
+
+  let assert Ok(monitored) = event_manager.start_monitor(options)
+
+  event_manager.stop(monitored.manager)
+}


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes in this PR. -->

## Related Issue

<!-- Link to the issue this PR addresses, if any. -->
<!-- Use "Closes #123" to auto-close the issue on merge. -->

- Closes #15 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `gleam format` run
