### PR TITLE
feat: adding support for reqids API (need OTP 25+)

### DIFF
--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -10,6 +10,7 @@
 //// - Returns strongly-typed Steps instead of various tuple formats
 ////
 
+import gleam/dynamic.{type Dynamic}
 import gleam/erlang/atom.{type Atom}
 import gleam/erlang/process.{type ExitReason, type Pid, type Subject}
 import gleam/option.{type Option, None, Some}
@@ -148,6 +149,38 @@ pub type StartError {
 /// Convenience type for start results.
 pub type StartResult(data) =
   Result(Started(data), StartError)
+
+/// An opaque request ID returned by `send_request`.
+///
+/// The phantom type `reply` tracks the expected response type at compile time.
+/// Requires Erlang/OTP 25.0 or later.
+///
+pub type ReqId(reply)
+
+/// A collection of in-flight request IDs, each associated with a `label`.
+///
+/// Used with `send_request_to_collection`, `reqids_add`, and
+/// `receive_response_collection` to manage multiple concurrent requests.
+/// Requires Erlang/OTP 25.0 or later.
+///
+pub type ReqIdCollection(label, reply)
+
+/// The result of waiting for a response from a `ReqIdCollection`.
+///
+pub type CollectionResponse(reply, label) {
+  /// A successful reply was received for one of the pending requests.
+  GotReply(reply: reply, label: label, remaining: ReqIdCollection(label, reply))
+
+  /// One of the requests returned an error (e.g. the server crashed).
+  RequestFailed(
+    reason: Dynamic,
+    label: label,
+    remaining: ReqIdCollection(label, reply),
+  )
+
+  /// The collection had no pending requests.
+  NoRequests
+}
 
 /// Create a new state machine builder with initial state and data.
 ///
@@ -564,3 +597,124 @@ pub fn call(
 ) -> reply {
   process.call(subject, timeout, make_message)
 }
+
+// ── reqids API (OTP 25.0+) ─────────────────────────────────────────────────
+
+/// Create a new, empty request-id collection.
+///
+/// Used with `send_request_to_collection` to batch multiple async requests and
+/// then receive them through `receive_response_collection`.
+///
+/// Requires Erlang/OTP 25.0 or later.
+///
+@external(erlang, "statem_ffi", "reqids_new")
+pub fn reqids_new() -> ReqIdCollection(label, reply)
+
+/// Add a `ReqId` to a collection under a `label`.
+///
+/// The label is returned alongside the reply in `receive_response_collection`,
+/// letting you identify which request the response belongs to.
+///
+/// Requires Erlang/OTP 25.0 or later.
+///
+@external(erlang, "statem_ffi", "reqids_add")
+pub fn reqids_add(
+  req_id req_id: ReqId(reply),
+  label label: label,
+  to collection: ReqIdCollection(label, reply),
+) -> ReqIdCollection(label, reply)
+
+/// Return the number of pending request IDs in a collection.
+///
+/// Requires Erlang/OTP 25.0 or later.
+///
+@external(erlang, "statem_ffi", "reqids_size")
+pub fn reqids_size(collection: ReqIdCollection(label, reply)) -> Int
+
+/// Convert a collection to a list of `#(ReqId, label)` pairs.
+///
+/// Requires Erlang/OTP 25.0 or later.
+///
+@external(erlang, "statem_ffi", "reqids_to_list")
+pub fn reqids_to_list(
+  collection: ReqIdCollection(label, reply),
+) -> List(#(ReqId(reply), label))
+
+/// Send an asynchronous call to a state machine and return a `ReqId`.
+///
+/// Unlike `call`, this does not block. Use `receive_response` later to
+/// collect the reply. The server receives a `Call(from, message)` event
+/// and must reply with a `Reply(from, value)` action.
+///
+/// The `reply` type cannot always be inferred — annotate the binding when
+/// needed: `let req: ReqId(MyReply) = send_request(subject, MyMsg)`
+///
+/// ## Example
+///
+/// ```gleam
+/// let req: state_machine.ReqId(Int) = state_machine.send_request(machine.data, GetCount)
+/// // ... do other work ...
+/// let assert Ok(count) = state_machine.receive_response(req, 1000)
+/// ```
+///
+/// Requires Erlang/OTP 25.0 or later.
+///
+@external(erlang, "statem_ffi", "send_request")
+pub fn send_request(subject: Subject(msg), message: msg) -> ReqId(reply)
+
+/// Send an asynchronous call and immediately add the `ReqId` to a collection.
+///
+/// Equivalent to calling `send_request` and `reqids_add` in one step. Useful
+/// for issuing several requests in a loop before waiting for any of them.
+///
+/// ## Example
+///
+/// ```gleam
+/// let coll: state_machine.ReqIdCollection(String, Int) = state_machine.reqids_new()
+/// let coll = state_machine.send_request_to_collection(sub, GetCount, "first", coll)
+/// let coll = state_machine.send_request_to_collection(sub, GetCount, "second", coll)
+/// // ... receive responses via receive_response_collection ...
+/// ```
+///
+/// Requires Erlang/OTP 25.0 or later.
+///
+@external(erlang, "statem_ffi", "send_request_to_collection")
+pub fn send_request_to_collection(
+  subject: Subject(msg),
+  message: msg,
+  label: label,
+  to collection: ReqIdCollection(label, reply),
+) -> ReqIdCollection(label, reply)
+
+/// Wait up to `timeout` milliseconds for the reply to a single `ReqId`.
+///
+/// Returns `Ok(reply)` on success or `Error(reason)` on failure or timeout.
+///
+/// Requires Erlang/OTP 25.0 or later.
+///
+@external(erlang, "statem_ffi", "receive_response")
+pub fn receive_response(
+  req_id: ReqId(reply),
+  timeout: Int,
+) -> Result(reply, Dynamic)
+
+/// Wait up to `timeout` milliseconds for any pending reply in a collection.
+///
+/// When `delete` is `True`, the matched request is removed from the returned
+/// collection. Call this in a loop to drain all responses one by one.
+///
+/// ## Example
+///
+/// ```gleam
+/// let assert state_machine.GotReply(val, label, coll) =
+///   state_machine.receive_response_collection(coll, 1000, True)
+/// ```
+///
+/// Requires Erlang/OTP 25.0 or later.
+///
+@external(erlang, "statem_ffi", "receive_response_collection")
+pub fn receive_response_collection(
+  collection: ReqIdCollection(label, reply),
+  timeout: Int,
+  delete: Bool,
+) -> CollectionResponse(reply, label)

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -8,6 +8,16 @@ gen_statem behavior callbacks and Gleam's type-safe API.
 
 %% Public API
 -export([do_start/7, cast/2]).
+-export([
+    reqids_new/0,
+    reqids_add/3,
+    reqids_size/1,
+    reqids_to_list/1,
+    send_request/2,
+    send_request_to_collection/4,
+    receive_response/2,
+    receive_response_collection/3
+]).
 
 %% gen_statem callbacks
 -export([
@@ -349,6 +359,80 @@ cast(Subject, Msg) ->
         end,
     gen_statem:cast(Pid, Msg),
     nil.
+
+%%%===================================================================
+%%% reqids API — OTP 25.0+
+%%%===================================================================
+
+-doc "Creates a new empty request-id collection.".
+reqids_new() ->
+    gen_statem:reqids_new().
+
+-doc "Adds a request id to a collection under the given label.".
+reqids_add(ReqId, Label, Collection) ->
+    gen_statem:reqids_add(ReqId, Label, Collection).
+
+-doc "Returns the number of request ids in the collection.".
+reqids_size(Collection) ->
+    gen_statem:reqids_size(Collection).
+
+-doc "Converts the collection to a list of {ReqId, Label} pairs.".
+reqids_to_list(Collection) ->
+    gen_statem:reqids_to_list(Collection).
+
+-doc """
+Sends an asynchronous call request to a gen_statem process and returns a
+request id. The server receives a `Call(from, msg)` event and must respond
+with a `Reply(from, value)` action. Use `receive_response/2` to collect the
+reply when ready.
+""".
+send_request({subject, Pid, _Tag}, Msg) ->
+    gen_statem:send_request(Pid, Msg);
+send_request({named_subject, Name}, Msg) ->
+    case erlang:whereis(Name) of
+        Pid when is_pid(Pid) -> gen_statem:send_request(Pid, Msg);
+        undefined -> error({noproc, Name})
+    end.
+
+-doc """
+Like `send_request/2` but also adds the resulting request id (under `Label`)
+to `Collection`, returning the updated collection.
+""".
+send_request_to_collection({subject, Pid, _Tag}, Msg, Label, Collection) ->
+    gen_statem:send_request(Pid, Msg, Label, Collection);
+send_request_to_collection({named_subject, Name}, Msg, Label, Collection) ->
+    case erlang:whereis(Name) of
+        Pid when is_pid(Pid) -> gen_statem:send_request(Pid, Msg, Label, Collection);
+        undefined -> error({noproc, Name})
+    end.
+
+-doc """
+Waits up to `Timeout` milliseconds for the reply to a single `ReqId`.
+Returns `{ok, Reply}` on success or `{error, Reason}` on failure/timeout.
+""".
+receive_response(ReqId, Timeout) ->
+    case gen_statem:receive_response(ReqId, Timeout) of
+        {reply, Reply} -> {ok, Reply};
+        {error, {Reason, _ServerRef}} -> {error, Reason}
+    end.
+
+-doc """
+Waits up to `Timeout` milliseconds for any reply in `Collection`.
+When `Delete` is `true` the matched request is removed from the returned
+collection. Maps to Gleam's `CollectionResponse` constructors:
+  `{got_reply, Reply, Label, NewColl}`
+  `{request_failed, Reason, Label, NewColl}`
+  `no_requests`
+""".
+receive_response_collection(Collection, Timeout, Delete) ->
+    case gen_statem:receive_response(Collection, Timeout, Delete) of
+        {{reply, Reply}, Label, NewColl} ->
+            {got_reply, Reply, Label, NewColl};
+        {{error, {Reason, _ServerRef}}, Label, NewColl} ->
+            {request_failed, Reason, Label, NewColl};
+        no_request ->
+            no_requests
+    end.
 
 -doc """
 Converts a Gleam ExitReason to an Erlang exit reason term.

--- a/test/actions_test.gleam
+++ b/test/actions_test.gleam
@@ -1,6 +1,6 @@
 ////
 //// Integration tests for gen_statem actions: Stop, Postpone, NextEvent,
-//// StateTimeout, GenericTimeout, and Cast.
+//// StateTimeout, GenericTimeout, Cast, and reqids (send_request).
 ////
 //// Each section has its own state/msg types, prefixed to avoid constructor
 //// name collisions across sections.
@@ -9,6 +9,7 @@
 import eparch/state_machine
 import gleam/erlang/atom
 import gleam/erlang/process
+import gleam/list
 import gleeunit/should
 
 // STOP
@@ -423,4 +424,158 @@ pub fn push_then_pop_callback_module_roundtrip_test() {
 
   let assert Ok(reply) = process.receive(reply_sub, 1000)
   reply |> should.equal("pong")
+}
+
+// REQIDS (send_request / OTP 25+)
+//
+// The server receives Call(from, msg) events and must reply with the
+// Reply(from, value) action. This is different from the Info-based pattern
+// used by state_machine.call / process.call.
+//
+
+type ReqState {
+  ReqRunning
+}
+
+type ReqMsg {
+  GetCounter
+  Increment
+}
+
+fn reqid_handler(
+  event: state_machine.Event(ReqState, ReqMsg, Int),
+  _state: ReqState,
+  data: Int,
+) -> state_machine.Step(ReqState, Int, ReqMsg, Int) {
+  case event {
+    state_machine.Call(from, GetCounter) ->
+      state_machine.keep_state(data, [state_machine.Reply(from, data)])
+    state_machine.Info(Increment) -> state_machine.keep_state(data + 1, [])
+    _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn send_request_returns_reply_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ReqRunning, initial_data: 0)
+    |> state_machine.on_event(reqid_handler)
+    |> state_machine.start
+
+  let req: state_machine.ReqId(Int) =
+    state_machine.send_request(machine.data, GetCounter)
+  let assert Ok(count) = state_machine.receive_response(req, 1000)
+  count |> should.equal(0)
+}
+
+pub fn send_request_sees_latest_state_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ReqRunning, initial_data: 0)
+    |> state_machine.on_event(reqid_handler)
+    |> state_machine.start
+
+  process.send(machine.data, Increment)
+  process.send(machine.data, Increment)
+
+  let req: state_machine.ReqId(Int) =
+    state_machine.send_request(machine.data, GetCounter)
+  let assert Ok(count) = state_machine.receive_response(req, 1000)
+  count |> should.equal(2)
+}
+
+pub fn reqids_size_reflects_pending_requests_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ReqRunning, initial_data: 0)
+    |> state_machine.on_event(reqid_handler)
+    |> state_machine.start
+
+  let coll: state_machine.ReqIdCollection(String, Int) =
+    state_machine.reqids_new()
+  state_machine.reqids_size(coll) |> should.equal(0)
+
+  let coll =
+    state_machine.send_request_to_collection(
+      machine.data,
+      GetCounter,
+      "first",
+      coll,
+    )
+  state_machine.reqids_size(coll) |> should.equal(1)
+
+  let coll =
+    state_machine.send_request_to_collection(
+      machine.data,
+      GetCounter,
+      "second",
+      coll,
+    )
+  state_machine.reqids_size(coll) |> should.equal(2)
+
+  let assert state_machine.GotReply(_, _, coll) =
+    state_machine.receive_response_collection(coll, 1000, True)
+  let assert state_machine.GotReply(_, _, coll) =
+    state_machine.receive_response_collection(coll, 1000, True)
+  state_machine.reqids_size(coll) |> should.equal(0)
+}
+
+pub fn send_request_to_collection_delivers_both_replies_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ReqRunning, initial_data: 42)
+    |> state_machine.on_event(reqid_handler)
+    |> state_machine.start
+
+  let coll: state_machine.ReqIdCollection(String, Int) =
+    state_machine.reqids_new()
+  let coll =
+    state_machine.send_request_to_collection(machine.data, GetCounter, "a", coll)
+  let coll =
+    state_machine.send_request_to_collection(machine.data, GetCounter, "b", coll)
+
+  let assert state_machine.GotReply(v1, _l1, coll) =
+    state_machine.receive_response_collection(coll, 1000, True)
+  let assert state_machine.GotReply(v2, _l2, _) =
+    state_machine.receive_response_collection(coll, 1000, True)
+
+  v1 |> should.equal(42)
+  v2 |> should.equal(42)
+}
+
+pub fn reqids_to_list_contains_all_entries_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ReqRunning, initial_data: 0)
+    |> state_machine.on_event(reqid_handler)
+    |> state_machine.start
+
+  let coll: state_machine.ReqIdCollection(String, Int) =
+    state_machine.reqids_new()
+  let coll =
+    state_machine.send_request_to_collection(machine.data, GetCounter, "x", coll)
+  let coll =
+    state_machine.send_request_to_collection(machine.data, GetCounter, "y", coll)
+
+  let entries = state_machine.reqids_to_list(coll)
+  list.length(entries) |> should.equal(2)
+
+  let assert state_machine.GotReply(_, _, coll) =
+    state_machine.receive_response_collection(coll, 1000, True)
+  let assert state_machine.GotReply(_, _, _) =
+    state_machine.receive_response_collection(coll, 1000, True)
+}
+
+pub fn reqids_add_manually_adds_to_collection_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ReqRunning, initial_data: 7)
+    |> state_machine.on_event(reqid_handler)
+    |> state_machine.start
+
+  let req: state_machine.ReqId(Int) =
+    state_machine.send_request(machine.data, GetCounter)
+  let coll: state_machine.ReqIdCollection(String, Int) =
+    state_machine.reqids_new()
+  let coll = state_machine.reqids_add(req_id: req, label: "manual", to: coll)
+  state_machine.reqids_size(coll) |> should.equal(1)
+
+  let assert state_machine.GotReply(val, label, _) =
+    state_machine.receive_response_collection(coll, 1000, True)
+  val |> should.equal(7)
+  label |> should.equal("manual")
 }

--- a/test/actions_test.gleam
+++ b/test/actions_test.gleam
@@ -526,9 +526,19 @@ pub fn send_request_to_collection_delivers_both_replies_test() {
   let coll: state_machine.ReqIdCollection(String, Int) =
     state_machine.reqids_new()
   let coll =
-    state_machine.send_request_to_collection(machine.data, GetCounter, "a", coll)
+    state_machine.send_request_to_collection(
+      machine.data,
+      GetCounter,
+      "a",
+      coll,
+    )
   let coll =
-    state_machine.send_request_to_collection(machine.data, GetCounter, "b", coll)
+    state_machine.send_request_to_collection(
+      machine.data,
+      GetCounter,
+      "b",
+      coll,
+    )
 
   let assert state_machine.GotReply(v1, _l1, coll) =
     state_machine.receive_response_collection(coll, 1000, True)
@@ -548,9 +558,19 @@ pub fn reqids_to_list_contains_all_entries_test() {
   let coll: state_machine.ReqIdCollection(String, Int) =
     state_machine.reqids_new()
   let coll =
-    state_machine.send_request_to_collection(machine.data, GetCounter, "x", coll)
+    state_machine.send_request_to_collection(
+      machine.data,
+      GetCounter,
+      "x",
+      coll,
+    )
   let coll =
-    state_machine.send_request_to_collection(machine.data, GetCounter, "y", coll)
+    state_machine.send_request_to_collection(
+      machine.data,
+      GetCounter,
+      "y",
+      coll,
+    )
 
   let entries = state_machine.reqids_to_list(coll)
   list.length(entries) |> should.equal(2)


### PR DESCRIPTION
## Description

Adds type-safe wrappers for `gen_statem`'s request ID collection API introduced in OTP 25.0.

**New types:**
- `ReqId(reply)`: opaque request ID with phantom reply type
- `ReqIdCollection(label, reply)`: collection of in-flight request IDs keyed by label
- `CollectionResponse(reply, label)`:  result of waiting on a collection (`GotReply`, `RequestFailed`, `NoRequests`)

**New functions (Gleam API + FFI):**
- `reqids_new/0`, `reqids_add/3`, `reqids_size/1`, `reqids_to_list/1`: collection management
- `send_request/2`: async call to a state machine, returns a `ReqId` without blocking
- `send_request_to_collection/4`: `send_request` + `reqids_add` in one step
- `receive_response/2`: wait for a single `ReqId`
- `receive_response_collection/3`: wait for any reply in a collection

Unlike `call` (which routes through `process.send` and arrives as `Info`), `send_request` uses OTP's native call mechanism, the server receives a `Call(from, msg)` event and replies with the existing `Reply(from, value)` action.

## Related Issue

- Closes [Issue 36](https://github.com/schonfinkel/eparch/issues/36)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated (if applicable)
- [x] `gleam format` run