### PR TITLE
#28 ADD gen_statem support for format_status/2

### DIFF
--- a/src/eparch/.state_machine.gleam.~undo-tree~
+++ b/src/eparch/.state_machine.gleam.~undo-tree~
@@ -1,9 +1,0 @@
-(undo-tree-save-format-version . 1)
-"940e9f50ed33a7d1859837fd0f14d6f7e4323b24"
-[nil nil nil nil (27094 57571 600841 504000) 0 nil]
-([nil nil ((975 . 980) (" " . -975) (undo-tree-id22 . -1) (undo-tree-id23 . -1) (undo-tree-id24 . -1) (undo-tree-id25 . -1) (undo-tree-id26 . -1) (undo-tree-id27 . -1) (undo-tree-id28 . -1) ("i" . -976) (undo-tree-id29 . -1) (undo-tree-id30 . -1) (undo-tree-id31 . -1) (undo-tree-id32 . -1) (undo-tree-id33 . -1) ("n" . -977) (undo-tree-id34 . -1) (undo-tree-id35 . -1) (undo-tree-id36 . -1) 978 (976 . 978) (" " . -976) (undo-tree-id37 . -1) 977 (975 . 977) (970 . 975) ("r" . -970) (undo-tree-id38 . -1) 971 (966 . 971) (965 . 966) (961 . 965) ("ty" . -961) (undo-tree-id39 . -2) (undo-tree-id40 . -2) (undo-tree-id41 . -2) 963 (961 . 963) ("t" . -961) (undo-tree-id42 . -1) (undo-tree-id43 . -1) (undo-tree-id44 . -1) ("y" . -962) (undo-tree-id45 . -1) (undo-tree-id46 . -1) (undo-tree-id47 . -1) ("p" . -963) (undo-tree-id48 . -1) ("o" . -964) (undo-tree-id49 . -1) ("e" . -965) (undo-tree-id50 . -1) 966 (963 . 966) ("e" . -963) (undo-tree-id51 . -1) ("p" . -964) (undo-tree-id52 . -1) 965 (961 . 965) (960 . 961) (959 . 960) (t 27094 57543 959056 123000) 958) nil (27094 57571 600840 101000) 0 nil])
-([nil nil (("type StateMachine {
-" . 961) (undo-tree-id2 . -19) (undo-tree-id3 . -20) (undo-tree-id4 . -20) (undo-tree-id5 . -20) (undo-tree-id6 . -20) (undo-tree-id7 . -20) (undo-tree-id8 . -20) (undo-tree-id9 . -14) (undo-tree-id10 . -14) (undo-tree-id11 . -18) (undo-tree-id12 . -14) (undo-tree-id13 . -14) (undo-tree-id14 . -14) (undo-tree-id15 . 1) (undo-tree-id16 . -18) (undo-tree-id17 . -18) (undo-tree-id18 . -18) (undo-tree-id19 . -18) (undo-tree-id20 . -18) (undo-tree-id21 . -20) 979) nil (27094 57571 600827 888000) 0 nil])
-([nil current (("
-" . 961) (undo-tree-id0 . 1) (undo-tree-id1 . -1)) nil (27094 57571 600812 899000) 0 nil])
-nil

--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -1,12 +1,12 @@
 //// A type-safe, OTP-compatible, finite state machine implementation that
-//// leverages Erlang's [gen_statem](https://www.erlang.org/doc/apps/stdlib/gen_statem.html) behavior throught the [Gleam ffi](https://gleam.run/documentation/externals/#Erlang-externals).
+//// leverages Erlang's [gen_statem](https://www.erlang.org/doc/apps/stdlib/gen_statem.html) behavior through the [Gleam ffi](https://gleam.run/documentation/externals/#Erlang-externals).
 ////
 //// ## Differences from `gen_statem`
 ////
 //// Unlike Erlang's `gen_statem`, this implementation:
 //// - Uses a single `Event` type to unify calls, casts, and info messages
 //// - Makes actions explicit and type-safe (no raw tuples)
-//// - Makes [state_enter](https://www.erlang.org/doc/apps/stdlib/gen_statem.html#t:state_enter/0) an opt-in feature, you need to explicity set it so in the Builder.
+//// - Makes [state_enter](https://www.erlang.org/doc/apps/stdlib/gen_statem.html#t:state_enter/0) an opt-in feature, you need to explicitly set it so in the Builder.
 //// - Returns strongly-typed Steps instead of various tuple formats
 ////
 
@@ -25,20 +25,88 @@ type StateEnter {
 /// Generic parameters:
 /// - `state`: The type of state values (e.g., enum, custom type)
 /// - `data`: The type of data carried across state transitions
-/// - `msg`: The type of messages the state machine receives
+/// - `message`: The type of messages the state machine receives
 /// - `return`: What the start function returns to the parent
+/// - `reply`: The type of replies produced for synchronous `Call` events
 ///
-pub opaque type Builder(state, data, msg, return, reply) {
+pub opaque type Builder(state, data, message, return, reply) {
   Builder(
     initial_state: state,
     initial_data: data,
-    event_handler: fn(Event(state, msg, reply), state, data) ->
-      Step(state, data, msg, reply),
+    event_handler: fn(Event(state, message, reply), state, data) ->
+      Step(state, data, message, reply),
     state_enter: StateEnter,
     initialisation_timeout: Int,
-    name: Option(process.Name(msg)),
+    name: Option(process.Name(message)),
     on_code_change: Option(fn(data) -> data),
+    on_format_status: Option(
+      fn(Status(state, data, message, reply)) ->
+        Status(state, data, message, reply),
+    ),
   )
+}
+
+/// Snapshot of the state machine passed to the `format_status` callback.
+///
+/// Mirrors the OTP 25+ `format_status/1` map for `gen_statem`. The `state`
+/// and `data` fields always carry the current typed values. The remaining
+/// fields correspond to OTP map keys that are only present in certain
+/// contexts (e.g. `reason` during termination, `queue` during sys calls).
+/// Return a modified `Status` from your formatter to control what
+/// `sys:get_status/1` and SASL crash reports display.
+///
+/// `log` stays as `List(Dynamic)` because `sys:system_event()` is an
+/// internal Erlang shape with no stable Gleam equivalent.
+///
+pub type Status(state, data, message, reply) {
+  Status(
+    state: state,
+    data: data,
+    reason: Option(StopReason),
+    queue: List(QueuedEvent(message, reply)),
+    postponed: List(QueuedEvent(message, reply)),
+    timeouts: List(ActiveTimeout(message)),
+    log: List(Dynamic),
+  )
+}
+
+/// Termination reason as seen by `format_status/1`.
+///
+/// `Exit` wraps a recognised `process.ExitReason`. `RawReason` is a fallback
+/// for reasons the FFI cannot classify (e.g. `{shutdown, _}`, `{noproc, _}`,
+/// arbitrary user terms) so callers can still inspect or replace them.
+///
+pub type StopReason {
+  Exit(reason: ExitReason)
+  RawReason(term: Dynamic)
+}
+
+/// A pending event on the gen_statem queue or in the postponed list.
+///
+/// Mirrors the `Event` type but without the `Enter` variant (state-entry
+/// events never queue). `QueuedOther` is a fallback for shapes the FFI does
+/// not recognise, so the formatter never crashes on an unexpected OTP event
+/// type.
+///
+pub type QueuedEvent(message, reply) {
+  QueuedCall(from: From(reply), message: message)
+  QueuedCast(message: message)
+  QueuedInfo(message: message)
+  QueuedInternal(message: message)
+  QueuedStateTimeout(content: message)
+  QueuedGenericTimeout(name: String, content: message)
+  QueuedOther(raw: Dynamic)
+}
+
+/// An armed (not-yet-fired) timeout on the state machine.
+///
+/// `ActiveOtherTimeout` handles any shape the FFI cannot classify as a
+/// state or generic timeout.
+///
+pub type ActiveTimeout(message) {
+  ActiveStateTimeout(content: message)
+  ActiveGenericTimeout(name: String, content: message)
+  ActiveOtherTimeout(raw: Dynamic)
 }
 
 /// Events that a state machine can receive.
@@ -48,15 +116,15 @@ pub opaque type Builder(state, data, msg, return, reply) {
 /// - Casts (asynchronous / fire-and-forget)
 /// - Info (other messages, from selectors/monitors)
 ///
-pub type Event(state, msg, reply) {
+pub type Event(state, message, reply) {
   /// A synchronous call that expects a reply
-  Call(from: From(reply), message: msg)
+  Call(from: From(reply), message: message)
 
   /// An asynchronous cast (fire-and-forget)
-  Cast(message: msg)
+  Cast(message: message)
 
   /// An info message (from selectors, monitors, etc)
-  Info(message: msg)
+  Info(message: message)
 
   /// Internal event fired when entering a state (if state_enter enabled)
   /// Contains the previous state
@@ -70,12 +138,12 @@ pub type Event(state, msg, reply) {
 ///
 /// Indicates what the state machine should do next.
 ///
-pub type Step(state, data, msg, reply) {
+pub type Step(state, data, message, reply) {
   /// Transition to a new state
-  NextState(state: state, data: data, actions: List(Action(msg, reply)))
+  NextState(state: state, data: data, actions: List(Action(message, reply)))
 
   /// Keep the current state
-  KeepState(data: data, actions: List(Action(msg, reply)))
+  KeepState(data: data, actions: List(Action(message, reply)))
 
   /// Stop the state machine
   Stop(reason: ExitReason)
@@ -85,7 +153,7 @@ pub type Step(state, data, msg, reply) {
 ///
 /// Multiple actions can be returned as a list.
 ///
-pub type Action(msg, reply) {
+pub type Action(message, reply) {
   /// Send a reply to a caller
   Reply(from: From(reply), response: reply)
 
@@ -93,7 +161,7 @@ pub type Action(msg, reply) {
   Postpone
 
   /// Insert a new event at the front of the queue
-  NextEvent(content: msg)
+  NextEvent(content: message)
 
   /// Set a state timeout (canceled on state change)
   StateTimeout(milliseconds: Int)
@@ -155,27 +223,48 @@ pub type StartResult(data) =
 /// The phantom type `reply` tracks the expected response type at compile time.
 /// Requires Erlang/OTP 25.0 or later.
 ///
-pub type ReqId(reply)
+pub type RequestId(reply)
 
 /// A collection of in-flight request IDs, each associated with a `label`.
 ///
-/// Used with `send_request_to_collection`, `reqids_add`, and
+/// Used with `send_request_to_collection`, `request_ids_add`, and
 /// `receive_response_collection` to manage multiple concurrent requests.
 /// Requires Erlang/OTP 25.0 or later.
 ///
-pub type ReqIdCollection(label, reply)
+pub type RequestIdCollection(label, reply)
 
-/// The result of waiting for a response from a `ReqIdCollection`.
+/// Whether `receive_response_collection` removes the matched request from
+/// the collection after delivering the reply.
+///
+pub type ResponseHandling {
+  Delete
+  Keep
+}
+
+/// Reasons `receive_response` and `receive_response_collection` can fail.
+///
+pub type ReceiveError {
+  /// No reply was received within the timeout.
+  ReceiveTimeout
+  /// The server handling the request crashed or went away.
+  RequestCrashed(reason: StopReason)
+}
+
+/// The result of waiting for a response from a `RequestIdCollection`.
 ///
 pub type CollectionResponse(reply, label) {
   /// A successful reply was received for one of the pending requests.
-  GotReply(reply: reply, label: label, remaining: ReqIdCollection(label, reply))
+  GotReply(
+    reply: reply,
+    label: label,
+    remaining: RequestIdCollection(label, reply),
+  )
 
   /// One of the requests returned an error (e.g. the server crashed).
   RequestFailed(
-    reason: Dynamic,
+    reason: StopReason,
     label: label,
-    remaining: ReqIdCollection(label, reply),
+    remaining: RequestIdCollection(label, reply),
   )
 
   /// The collection had no pending requests.
@@ -198,7 +287,7 @@ pub type CollectionResponse(reply, label) {
 pub fn new(
   initial_state initial_state: state,
   initial_data initial_data: data,
-) -> Builder(state, data, msg, Subject(msg), reply) {
+) -> Builder(state, data, message, Subject(message), reply) {
   Builder(
     initial_state: initial_state,
     initial_data: initial_data,
@@ -207,6 +296,7 @@ pub fn new(
     initialisation_timeout: 1000,
     name: None,
     on_code_change: None,
+    on_format_status: None,
   )
 }
 
@@ -219,15 +309,15 @@ pub fn new(
 /// ## Example
 ///
 /// ```gleam
-/// fn handle_event(event, state, data) {
-///   case event, state {
-///     Call(from, GetCount), Running ->
-///       keep_state(data, [Reply(from, data.count)])
-///
-///     Cast(Increment), Running ->
-///       keep_state(Data(..data, count: data.count + 1), [])
-///
-///     _, _ -> keep_state(data, [])
+/// fn handle_event(event, _state, data) {
+///   case event {
+///     Call(from, GetCount) -> reply_and_keep(from, data.count, data)
+///     Cast(Increment) -> keep_state(Data(..data, count: data.count + 1), [])
+///     Call(_, _) -> keep_state(data, [])
+///     Cast(_) -> keep_state(data, [])
+///     Info(_) -> keep_state(data, [])
+///     Enter(_) -> keep_state(data, [])
+///     Timeout(_) -> keep_state(data, [])
 ///   }
 /// }
 ///
@@ -237,10 +327,10 @@ pub fn new(
 /// ```
 ///
 pub fn on_event(
-  builder: Builder(state, data, msg, return, reply),
-  handler: fn(Event(state, msg, reply), state, data) ->
-    Step(state, data, msg, reply),
-) -> Builder(state, data, msg, return, reply) {
+  builder: Builder(state, data, message, return, reply),
+  handler: fn(Event(state, message, reply), state, data) ->
+    Step(state, data, message, reply),
+) -> Builder(state, data, message, return, reply) {
   Builder(..builder, event_handler: handler)
 }
 
@@ -255,13 +345,13 @@ pub fn on_event(
 /// ## Example
 ///
 /// ```gleam
-/// fn handle_event(event, state, data) {
-///   case event, state {
-///     Enter(old), Active if old != Active -> {
-///       // Perform entry actions
-///       keep_state(data, [StateTimeout(30_000)])
-///     }
-///     _, _ -> keep_state(data, [])
+/// fn handle_event(event, _state, data) {
+///   case event {
+///     Enter(_old) -> keep_state(data, [StateTimeout(30_000)])
+///     Call(_, _) -> keep_state(data, [])
+///     Cast(_) -> keep_state(data, [])
+///     Info(_) -> keep_state(data, [])
+///     Timeout(_) -> keep_state(data, [])
 ///   }
 /// }
 ///
@@ -272,8 +362,8 @@ pub fn on_event(
 /// ```
 ///
 pub fn with_state_enter(
-  builder: Builder(state, data, msg, return, reply),
-) -> Builder(state, data, msg, return, reply) {
+  builder: Builder(state, data, message, return, reply),
+) -> Builder(state, data, message, return, reply) {
   Builder(..builder, state_enter: StateEnterEnabled)
 }
 
@@ -282,9 +372,9 @@ pub fn with_state_enter(
 /// This enables sending messages to it via a named subject.
 ///
 pub fn named(
-  builder: Builder(state, data, msg, return, reply),
-  name: process.Name(msg),
-) -> Builder(state, data, msg, return, reply) {
+  builder: Builder(state, data, message, return, reply),
+  name: process.Name(message),
+) -> Builder(state, data, message, return, reply) {
   Builder(..builder, name: Some(name))
 }
 
@@ -310,10 +400,41 @@ pub fn named(
 /// ```
 ///
 pub fn on_code_change(
-  builder: Builder(state, data, msg, return, reply),
+  builder: Builder(state, data, message, return, reply),
   handler: fn(data) -> data,
-) -> Builder(state, data, msg, return, reply) {
+) -> Builder(state, data, message, return, reply) {
   Builder(..builder, on_code_change: Some(handler))
+}
+
+/// Provide a formatter called when `sys:get_status/1` or SASL crash reports
+/// render the state machine.
+///
+/// Maps to OTP's [`format_status/1`](https://www.erlang.org/doc/apps/stdlib/gen_statem.html#c:format_status/1)
+/// gen_statem callback. The formatter receives a `Status` value containing
+/// the current state and data (plus optional fields described on the
+/// `Status` type) and returns a transformed `Status`. Use this to redact
+/// sensitive fields or produce a more readable representation.
+///
+/// If not set, `sys:get_status/1` receives the raw internal state without
+/// transformation.
+///
+/// ## Example
+///
+/// ```gleam
+/// state_machine.new(initial_state: Idle, initial_data: Credentials("secret"))
+/// |> state_machine.on_format_status(fn(status) {
+///   Status(..status, data: Credentials("<redacted>"))
+/// })
+/// |> state_machine.on_event(handle_event)
+/// |> state_machine.start
+/// ```
+///
+pub fn on_format_status(
+  builder: Builder(state, data, message, return, reply),
+  formatter: fn(Status(state, data, message, reply)) ->
+    Status(state, data, message, reply),
+) -> Builder(state, data, message, return, reply) {
+  Builder(..builder, on_format_status: Some(formatter))
 }
 
 /// Start the state machine process.
@@ -338,8 +459,8 @@ pub fn on_code_change(
 /// ```
 ///
 pub fn start(
-  builder: Builder(state, data, msg, Subject(msg), reply),
-) -> Result(Started(Subject(msg)), StartError) {
+  builder: Builder(state, data, message, Subject(message), reply),
+) -> StartResult(Subject(message)) {
   let Builder(
     initial_state:,
     initial_data:,
@@ -348,6 +469,7 @@ pub fn start(
     initialisation_timeout:,
     name:,
     on_code_change:,
+    on_format_status:,
   ) = builder
   do_start(
     initial_state,
@@ -357,6 +479,7 @@ pub fn start(
     initialisation_timeout,
     name,
     on_code_change,
+    on_format_status,
   )
 }
 
@@ -364,13 +487,17 @@ pub fn start(
 fn do_start(
   initial_state: state,
   initial_data: data,
-  event_handler: fn(Event(state, msg, reply), state, data) ->
-    Step(state, data, msg, reply),
+  event_handler: fn(Event(state, message, reply), state, data) ->
+    Step(state, data, message, reply),
   state_enter: StateEnter,
   initialisation_timeout: Int,
-  name: Option(process.Name(msg)),
+  name: Option(process.Name(message)),
   on_code_change: Option(fn(data) -> data),
-) -> Result(Started(Subject(msg)), StartError)
+  on_format_status: Option(
+    fn(Status(state, data, message, reply)) ->
+      Status(state, data, message, reply),
+  ),
+) -> Result(Started(Subject(message)), StartError)
 
 /// Create a NextState step indicating a state transition.
 ///
@@ -383,8 +510,8 @@ fn do_start(
 pub fn next_state(
   state: state,
   data: data,
-  actions: List(Action(msg, reply)),
-) -> Step(state, data, msg, reply) {
+  actions: List(Action(message, reply)),
+) -> Step(state, data, message, reply) {
   NextState(state:, data:, actions:)
 }
 
@@ -398,8 +525,8 @@ pub fn next_state(
 ///
 pub fn keep_state(
   data: data,
-  actions: List(Action(msg, reply)),
-) -> Step(state, data, msg, reply) {
+  actions: List(Action(message, reply)),
+) -> Step(state, data, message, reply) {
   KeepState(data:, actions:)
 }
 
@@ -411,7 +538,7 @@ pub fn keep_state(
 /// stop(process.Normal)
 /// ```
 ///
-pub fn stop(reason: ExitReason) -> Step(state, data, msg, reply) {
+pub fn stop(reason: ExitReason) -> Step(state, data, message, reply) {
   Stop(reason:)
 }
 
@@ -426,7 +553,7 @@ pub fn stop(reason: ExitReason) -> Step(state, data, msg, reply) {
 /// }
 /// ```
 ///
-pub fn reply(from: From(reply), response: reply) -> Action(msg, reply) {
+pub fn reply(from: From(reply), response: reply) -> Action(message, reply) {
   Reply(from:, response:)
 }
 
@@ -434,7 +561,7 @@ pub fn reply(from: From(reply), response: reply) -> Action(msg, reply) {
 ///
 /// Postpones the current event until after the next state change.
 ///
-pub fn postpone() -> Action(msg, reply) {
+pub fn postpone() -> Action(message, reply) {
   Postpone
 }
 
@@ -442,7 +569,7 @@ pub fn postpone() -> Action(msg, reply) {
 ///
 /// Inserts a new event at the front of the event queue.
 ///
-pub fn next_event(content: msg) -> Action(msg, reply) {
+pub fn next_event(content: message) -> Action(message, reply) {
   NextEvent(content:)
 }
 
@@ -450,7 +577,7 @@ pub fn next_event(content: msg) -> Action(msg, reply) {
 ///
 /// Sets a timeout that is automatically canceled when the state changes.
 ///
-pub fn state_timeout(milliseconds: Int) -> Action(msg, reply) {
+pub fn state_timeout(milliseconds: Int) -> Action(message, reply) {
   StateTimeout(milliseconds:)
 }
 
@@ -458,7 +585,10 @@ pub fn state_timeout(milliseconds: Int) -> Action(msg, reply) {
 ///
 /// Sets a named timeout that persists across state changes.
 ///
-pub fn generic_timeout(name: String, milliseconds: Int) -> Action(msg, reply) {
+pub fn generic_timeout(
+  name: String,
+  milliseconds: Int,
+) -> Action(message, reply) {
   GenericTimeout(name:, milliseconds:)
 }
 
@@ -477,7 +607,7 @@ pub fn generic_timeout(name: String, milliseconds: Int) -> Action(msg, reply) {
 /// state_machine.change_callback_module(atom.create("my_erlang_module"))
 /// ```
 ///
-pub fn change_callback_module(module: Atom) -> Action(msg, reply) {
+pub fn change_callback_module(module: Atom) -> Action(message, reply) {
   ChangeCallbackModule(module:)
 }
 
@@ -495,7 +625,7 @@ pub fn change_callback_module(module: Atom) -> Action(msg, reply) {
 /// state_machine.push_callback_module(atom.create("my_erlang_module"))
 /// ```
 ///
-pub fn push_callback_module(module: Atom) -> Action(msg, reply) {
+pub fn push_callback_module(module: Atom) -> Action(message, reply) {
   PushCallbackModule(module:)
 }
 
@@ -513,7 +643,7 @@ pub fn push_callback_module(module: Atom) -> Action(msg, reply) {
 /// state_machine.pop_callback_module()
 /// ```
 ///
-pub fn pop_callback_module() -> Action(msg, reply) {
+pub fn pop_callback_module() -> Action(message, reply) {
   PopCallbackModule
 }
 
@@ -530,7 +660,7 @@ pub fn reply_and_next(
   response: reply,
   state: state,
   data: data,
-) -> Step(state, data, msg, reply) {
+) -> Step(state, data, message, reply) {
   NextState(state:, data:, actions: [Reply(from:, response:)])
 }
 
@@ -546,27 +676,27 @@ pub fn reply_and_keep(
   from: From(reply),
   response: reply,
   data: data,
-) -> Step(state, data, msg, reply) {
+) -> Step(state, data, message, reply) {
   KeepState(data:, actions: [Reply(from:, response:)])
 }
 
 /// Send a message to a state machine via `process.send` (arrives as `Info`).
 ///
-/// The message is delivered to the handler as `Info(msg)`. Use this for
+/// The message is delivered to the handler as `Info(message)`. Use this for
 /// messages sent from processes that are not aware of this library, e.g.
 /// monitors, timers, or plain Erlang processes.
 ///
-/// To deliver messages as `Cast(msg)` instead, use `cast/2`.
+/// To deliver messages as `Cast(message)` instead, use `cast/2`.
 ///
-pub fn send(subject: Subject(msg), msg: msg) -> Nil {
-  process.send(subject, msg)
+pub fn send(subject: Subject(message), message: message) -> Nil {
+  process.send(subject, message)
 }
 
 /// Send an asynchronous cast to a state machine (arrives as `Cast`).
 ///
 /// Unlike `send`, which routes messages through `process.send` and delivers
-/// them as `Info(msg)`, this function calls `gen_statem:cast` so messages
-/// arrive as `Cast(msg)` in the event handler.
+/// them as `Info(message)`, this function calls `gen_statem:cast` so messages
+/// arrive as `Cast(message)` in the event handler.
 ///
 /// Use `cast` when you want to distinguish machine-level commands from
 /// ambient info messages (monitors, raw Erlang signals, etc.).
@@ -574,17 +704,20 @@ pub fn send(subject: Subject(msg), msg: msg) -> Nil {
 /// ## Example
 ///
 /// ```gleam
-/// fn handle_event(event, state, data) {
+/// fn handle_event(event, _state, data) {
 ///   case event {
 ///     Cast(Increment) -> keep_state(data + 1, [])
-///     Info(_)         -> keep_state(data, [])   // ignore ambient noise
-///     _               -> keep_state(data, [])
+///     Cast(_) -> keep_state(data, [])
+///     Info(_) -> keep_state(data, []) // ignore ambient noise
+///     Call(_, _) -> keep_state(data, [])
+///     Enter(_) -> keep_state(data, [])
+///     Timeout(_) -> keep_state(data, [])
 ///   }
 /// }
 /// ```
 ///
 @external(erlang, "statem_ffi", "cast")
-pub fn cast(subject: Subject(msg), msg: msg) -> Nil
+pub fn cast(subject: Subject(message), message: message) -> Nil
 
 /// Send a synchronous call and wait for a reply.
 ///
@@ -598,7 +731,7 @@ pub fn call(
   process.call(subject, timeout, make_message)
 }
 
-// ── reqids API (OTP 25.0+) ─────────────────────────────────────────────────
+// request-id API (OTP 25.0+)
 
 /// Create a new, empty request-id collection.
 ///
@@ -608,9 +741,9 @@ pub fn call(
 /// Requires Erlang/OTP 25.0 or later.
 ///
 @external(erlang, "statem_ffi", "reqids_new")
-pub fn reqids_new() -> ReqIdCollection(label, reply)
+pub fn request_ids_new() -> RequestIdCollection(label, reply)
 
-/// Add a `ReqId` to a collection under a `label`.
+/// Add a `RequestId` to a collection under a `label`.
 ///
 /// The label is returned alongside the reply in `receive_response_collection`,
 /// letting you identify which request the response belongs to.
@@ -618,61 +751,70 @@ pub fn reqids_new() -> ReqIdCollection(label, reply)
 /// Requires Erlang/OTP 25.0 or later.
 ///
 @external(erlang, "statem_ffi", "reqids_add")
-pub fn reqids_add(
-  req_id req_id: ReqId(reply),
+pub fn request_ids_add(
+  request_id request_id: RequestId(reply),
   label label: label,
-  to collection: ReqIdCollection(label, reply),
-) -> ReqIdCollection(label, reply)
+  to collection: RequestIdCollection(label, reply),
+) -> RequestIdCollection(label, reply)
 
 /// Return the number of pending request IDs in a collection.
 ///
 /// Requires Erlang/OTP 25.0 or later.
 ///
 @external(erlang, "statem_ffi", "reqids_size")
-pub fn reqids_size(collection: ReqIdCollection(label, reply)) -> Int
+pub fn request_ids_size(collection: RequestIdCollection(label, reply)) -> Int
 
-/// Convert a collection to a list of `#(ReqId, label)` pairs.
+/// Convert a collection to a list of `#(RequestId, label)` pairs.
 ///
 /// Requires Erlang/OTP 25.0 or later.
 ///
 @external(erlang, "statem_ffi", "reqids_to_list")
-pub fn reqids_to_list(
-  collection: ReqIdCollection(label, reply),
-) -> List(#(ReqId(reply), label))
+pub fn request_ids_to_list(
+  collection: RequestIdCollection(label, reply),
+) -> List(#(RequestId(reply), label))
 
-/// Send an asynchronous call to a state machine and return a `ReqId`.
+/// Send an asynchronous call to a state machine and return a `RequestId`.
 ///
 /// Unlike `call`, this does not block. Use `receive_response` later to
 /// collect the reply. The server receives a `Call(from, message)` event
 /// and must reply with a `Reply(from, value)` action.
 ///
-/// The `reply` type cannot always be inferred — annotate the binding when
-/// needed: `let req: ReqId(MyReply) = send_request(subject, MyMsg)`
+/// The `reply` type cannot always be inferred, so annotate the binding when
+/// needed: `let request: RequestId(MyReply) = send_request(subject, MyMsg)`
 ///
 /// ## Example
 ///
 /// ```gleam
-/// let req: state_machine.ReqId(Int) = state_machine.send_request(machine.data, GetCount)
+/// let request: state_machine.RequestId(Int) =
+///   state_machine.send_request(machine.data, GetCount)
 /// // ... do other work ...
-/// let assert Ok(count) = state_machine.receive_response(req, 1000)
+/// let assert Ok(count) = state_machine.receive_response(request, 1000)
 /// ```
 ///
 /// Requires Erlang/OTP 25.0 or later.
 ///
 @external(erlang, "statem_ffi", "send_request")
-pub fn send_request(subject: Subject(msg), message: msg) -> ReqId(reply)
+pub fn send_request(
+  subject: Subject(message),
+  message: message,
+) -> RequestId(reply)
 
-/// Send an asynchronous call and immediately add the `ReqId` to a collection.
+/// Send an asynchronous call and immediately add the `RequestId` to a
+/// collection.
 ///
-/// Equivalent to calling `send_request` and `reqids_add` in one step. Useful
-/// for issuing several requests in a loop before waiting for any of them.
+/// Equivalent to calling `send_request` and `request_ids_add` in one step.
+/// Useful for issuing several requests in a loop before waiting for any of
+/// them.
 ///
 /// ## Example
 ///
 /// ```gleam
-/// let coll: state_machine.ReqIdCollection(String, Int) = state_machine.reqids_new()
-/// let coll = state_machine.send_request_to_collection(sub, GetCount, "first", coll)
-/// let coll = state_machine.send_request_to_collection(sub, GetCount, "second", coll)
+/// let collection: state_machine.RequestIdCollection(String, Int) =
+///   state_machine.request_ids_new()
+/// let collection =
+///   state_machine.send_request_to_collection(sub, GetCount, "first", collection)
+/// let collection =
+///   state_machine.send_request_to_collection(sub, GetCount, "second", collection)
 /// // ... receive responses via receive_response_collection ...
 /// ```
 ///
@@ -680,41 +822,44 @@ pub fn send_request(subject: Subject(msg), message: msg) -> ReqId(reply)
 ///
 @external(erlang, "statem_ffi", "send_request_to_collection")
 pub fn send_request_to_collection(
-  subject: Subject(msg),
-  message: msg,
+  subject: Subject(message),
+  message: message,
   label: label,
-  to collection: ReqIdCollection(label, reply),
-) -> ReqIdCollection(label, reply)
+  to collection: RequestIdCollection(label, reply),
+) -> RequestIdCollection(label, reply)
 
-/// Wait up to `timeout` milliseconds for the reply to a single `ReqId`.
+/// Wait up to `timeout` milliseconds for the reply to a single `RequestId`.
 ///
-/// Returns `Ok(reply)` on success or `Error(reason)` on failure or timeout.
+/// Returns `Ok(reply)` on success, `Error(ReceiveTimeout)` if no reply
+/// arrives in time, or `Error(RequestCrashed(reason))` if the server
+/// terminated before replying.
 ///
 /// Requires Erlang/OTP 25.0 or later.
 ///
 @external(erlang, "statem_ffi", "receive_response")
 pub fn receive_response(
-  req_id: ReqId(reply),
+  request_id: RequestId(reply),
   timeout: Int,
-) -> Result(reply, Dynamic)
+) -> Result(reply, ReceiveError)
 
 /// Wait up to `timeout` milliseconds for any pending reply in a collection.
 ///
-/// When `delete` is `True`, the matched request is removed from the returned
-/// collection. Call this in a loop to drain all responses one by one.
+/// Pass `Delete` to remove the matched request from the returned collection,
+/// or `Keep` to retain it. Call this in a loop to drain all responses one by
+/// one.
 ///
 /// ## Example
 ///
 /// ```gleam
-/// let assert state_machine.GotReply(val, label, coll) =
-///   state_machine.receive_response_collection(coll, 1000, True)
+/// let assert state_machine.GotReply(value, label, collection) =
+///   state_machine.receive_response_collection(collection, 1000, state_machine.Delete)
 /// ```
 ///
 /// Requires Erlang/OTP 25.0 or later.
 ///
 @external(erlang, "statem_ffi", "receive_response_collection")
 pub fn receive_response_collection(
-  collection: ReqIdCollection(label, reply),
+  collection: RequestIdCollection(label, reply),
   timeout: Int,
-  delete: Bool,
+  handling: ResponseHandling,
 ) -> CollectionResponse(reply, label)

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -7,7 +7,7 @@ gen_statem behavior callbacks and Gleam's type-safe API.
 -behaviour(gen_statem).
 
 %% Public API
--export([do_start/7, cast/2]).
+-export([do_start/8, cast/2]).
 -export([
     reqids_new/0,
     reqids_add/3,
@@ -25,7 +25,8 @@ gen_statem behavior callbacks and Gleam's type-safe API.
     callback_mode/0,
     handle_event/4,
     terminate/3,
-    code_change/4
+    code_change/4,
+    format_status/1
 ]).
 
 %%%===================================================================
@@ -48,7 +49,9 @@ gen_statem behavior callbacks and Gleam's type-safe API.
     % - named: atom (the registered name)
     subject_tag,
     % none | {some, fn(data) -> data}
-    on_code_change
+    on_code_change,
+    % none | {some, fn(Status) -> Status}
+    on_format_status
 }).
 
 %%%===================================================================
@@ -59,7 +62,9 @@ gen_statem behavior callbacks and Gleam's type-safe API.
 Start a `gen_statem` process linked to the caller and return the Subject
 needed to send messages to it
 """.
--spec do_start(InitialState, InitialData, Handler, StateEnter, TimeOut, Name, OnCodeChange) ->
+-spec do_start(
+    InitialState, InitialData, Handler, StateEnter, TimeOut, Name, OnCodeChange, OnFormatStatus
+) ->
     Result
 when
     InitialState :: any(),
@@ -69,8 +74,11 @@ when
     TimeOut :: timeout(),
     Name :: process_name_option(),
     OnCodeChange :: any(),
+    OnFormatStatus :: any(),
     Result :: any().
-do_start(InitialState, InitialData, Handler, StateEnter, Timeout, Name, OnCodeChange) ->
+do_start(
+    InitialState, InitialData, Handler, StateEnter, Timeout, Name, OnCodeChange, OnFormatStatus
+) ->
     %% Ack channel: a unique reference the child process will use to
     %% send us the Subject it creates in init/1.
     AckTag = make_ref(),
@@ -78,7 +86,7 @@ do_start(InitialState, InitialData, Handler, StateEnter, Timeout, Name, OnCodeCh
 
     InitArgs =
         {init_args, InitialState, InitialData, Handler, StateEnter, Parent, AckTag, Name,
-            OnCodeChange},
+            OnCodeChange, OnFormatStatus},
 
     StartResult =
         case Name of
@@ -125,7 +133,8 @@ Creates the Subject for this process and sends it back to the parent
 through the ack channel before returning to gen_statem.
 """.
 init(
-    {init_args, InitialState, InitialData, Handler, StateEnter, Parent, AckTag, Name, OnCodeChange}
+    {init_args, InitialState, InitialData, Handler, StateEnter, Parent, AckTag, Name, OnCodeChange,
+        OnFormatStatus}
 ) ->
     %% Build the Subject and determine the tag used for message unwrapping.
     {Subject, SubjectTag} =
@@ -150,7 +159,8 @@ init(
         gleam_handler = Handler,
         state_enter = StateEnter,
         subject_tag = SubjectTag,
-        on_code_change = OnCodeChange
+        on_code_change = OnCodeChange,
+        on_format_status = OnFormatStatus
     },
 
     {ok, InitialState, GleamStatem}.
@@ -223,6 +233,148 @@ code_change(
             {some, F} -> F(Data)
         end,
     {ok, State, GleamStatem#gleam_statem{gleam_data = NewData}}.
+
+-doc """
+Format the state/data for `sys:get_status/1` and SASL crash reports.
+
+OTP 25+ semantics: receives a status map containing `state`, `data`, and an
+optional subset of `reason`, `queue`, `postponed`, `timeouts`, `log`. The
+internal `#gleam_statem{}` lives under `data`; we extract the user's
+`gleam_data` before calling the Gleam-side formatter, and write the
+formatter's returned value back into the map's `data` key unwrapped (the
+result is purely for display, never becomes the live process data).
+
+Keys that were absent from the input map are not introduced in the output,
+matching OTP's contract that `NewStatus` has the same elements as `Status`.
+""".
+format_status(
+    #{
+        state := State,
+        data := #gleam_statem{
+            on_format_status = OnFormatStatus,
+            gleam_data = GleamData,
+            subject_tag = SubjectTag
+        }
+    } = Status
+) ->
+    case OnFormatStatus of
+        none ->
+            Status;
+        {some, Fun} ->
+            Reason = classify_reason_opt(Status),
+            Queue = classify_queue_entries(maps:get(queue, Status, []), SubjectTag),
+            Postponed = classify_queue_entries(maps:get(postponed, Status, []), SubjectTag),
+            Timeouts = classify_timeouts(maps:get(timeouts, Status, [])),
+            Log = maps:get(log, Status, []),
+            %% Gleam Status record on the Erlang side:
+            %% {status, state, data, reason, queue, postponed, timeouts, log}
+            GleamStatus =
+                {status, State, GleamData, Reason, Queue, Postponed, Timeouts, Log},
+            {status, NewState, NewData, NewReason, NewQueue, NewPostponed, NewTimeouts, NewLog} =
+                Fun(GleamStatus),
+            %% maps:map/2 walks only the keys already in Status, so optional
+            %% keys that were absent in the input stay absent in the output,
+            %% honouring OTP's "NewStatus has the same elements as Status"
+            %% contract. The final clause passes through any future keys OTP
+            %% adds to the status map.
+            maps:map(
+                fun
+                    (state, _) ->
+                        NewState;
+                    (data, _) ->
+                        NewData;
+                    (reason, OrigReason) ->
+                        case NewReason of
+                            none -> OrigReason;
+                            {some, R} -> unclassify_reason(R)
+                        end;
+                    (queue, _) ->
+                        [unclassify_queue_entry(E) || E <- NewQueue];
+                    (postponed, _) ->
+                        [unclassify_queue_entry(E) || E <- NewPostponed];
+                    (timeouts, _) ->
+                        [unclassify_timeout(T) || T <- NewTimeouts];
+                    (log, _) ->
+                        NewLog;
+                    (_, V) ->
+                        V
+                end,
+                Status
+            )
+    end.
+
+%%%===================================================================
+%%% format_status: Erlang <-> Gleam conversions
+%%%
+%%% All classify_* converters aim for typed Gleam variants; any shape
+%%% we cannot confidently map is wrapped in an *_other variant carrying
+%%% the raw term, so format_status never crashes on unexpected input.
+%%%===================================================================
+
+classify_reason_opt(Status) ->
+    case maps:find(reason, Status) of
+        {ok, R} -> {some, classify_reason(R)};
+        error -> none
+    end.
+
+%% Gleam process.ExitReason is {normal} | {killed} | {abnormal, Term}.
+%% Wrap recognised shapes as Exit(...); everything else as RawReason(term).
+classify_reason(normal) -> {exit, {normal}};
+classify_reason(killed) -> {exit, {killed}};
+classify_reason({abnormal, T}) -> {exit, {abnormal, T}};
+classify_reason(Other) -> {raw_reason, Other}.
+
+unclassify_reason({exit, {normal}}) -> normal;
+unclassify_reason({exit, {killed}}) -> killed;
+unclassify_reason({exit, {abnormal, T}}) -> {abnormal, T};
+unclassify_reason({raw_reason, Term}) -> Term.
+
+classify_queue_entries(Entries, SubjectTag) ->
+    [classify_queue_entry(E, SubjectTag) || E <- Entries].
+
+classify_queue_entry({{call, From}, Content}, _) ->
+    {queued_call, From, Content};
+classify_queue_entry({cast, Content}, _) ->
+    {queued_cast, Content};
+classify_queue_entry({info, Content}, SubjectTag) ->
+    %% Match handle_event/4's behaviour: unwrap messages sent via the Subject,
+    %% pass through raw Erlang terms unchanged.
+    Msg =
+        case Content of
+            {SubjectTag, M} -> M;
+            _ -> Content
+        end,
+    {queued_info, Msg};
+classify_queue_entry({internal, Content}, _) ->
+    {queued_internal, Content};
+classify_queue_entry({state_timeout, Content}, _) ->
+    {queued_state_timeout, Content};
+classify_queue_entry({{timeout, Name}, Content}, _) when is_binary(Name) ->
+    {queued_generic_timeout, Name, Content};
+classify_queue_entry(Other, _) ->
+    {queued_other, Other}.
+
+unclassify_queue_entry({queued_call, From, Content}) -> {{call, From}, Content};
+unclassify_queue_entry({queued_cast, Content}) -> {cast, Content};
+unclassify_queue_entry({queued_info, Msg}) -> {info, Msg};
+unclassify_queue_entry({queued_internal, Content}) -> {internal, Content};
+unclassify_queue_entry({queued_state_timeout, Content}) -> {state_timeout, Content};
+unclassify_queue_entry({queued_generic_timeout, Name, Content}) -> {{timeout, Name}, Content};
+unclassify_queue_entry({queued_other, Raw}) -> Raw.
+
+classify_timeouts(Entries) ->
+    [classify_timeout(E) || E <- Entries].
+
+classify_timeout({state_timeout, Content}) ->
+    {active_state_timeout, Content};
+classify_timeout({{timeout, Name}, Content}) when is_binary(Name) ->
+    {active_generic_timeout, Name, Content};
+classify_timeout(Other) ->
+    {active_other_timeout, Other}.
+
+unclassify_timeout({active_state_timeout, Content}) -> {state_timeout, Content};
+unclassify_timeout({active_generic_timeout, Name, Content}) -> {{timeout, Name}, Content};
+unclassify_timeout({active_other_timeout, Raw}) -> Raw.
 
 %%%===================================================================
 %%% Event conversion from Erlang to Gleam
@@ -408,28 +560,39 @@ send_request_to_collection({named_subject, Name}, Msg, Label, Collection) ->
 
 -doc """
 Waits up to `Timeout` milliseconds for the reply to a single `ReqId`.
-Returns `{ok, Reply}` on success or `{error, Reason}` on failure/timeout.
+Returns `{ok, Reply}` on success, `{error, receive_timeout}` on timeout,
+or `{error, {request_crashed, StopReason}}` if the server terminated.
 """.
 receive_response(ReqId, Timeout) ->
     case gen_statem:receive_response(ReqId, Timeout) of
-        {reply, Reply} -> {ok, Reply};
-        {error, {Reason, _ServerRef}} -> {error, Reason}
+        {reply, Reply} ->
+            {ok, Reply};
+        timeout ->
+            {error, receive_timeout};
+        {error, {Reason, _ServerRef}} ->
+            {error, {request_crashed, classify_reason(Reason)}}
     end.
 
 -doc """
 Waits up to `Timeout` milliseconds for any reply in `Collection`.
-When `Delete` is `true` the matched request is removed from the returned
-collection. Maps to Gleam's `CollectionResponse` constructors:
+`Handling` is the atom `delete` (remove the matched request from the
+returned collection) or `keep`. Maps to Gleam's `CollectionResponse`
+constructors:
   `{got_reply, Reply, Label, NewColl}`
-  `{request_failed, Reason, Label, NewColl}`
+  `{request_failed, StopReason, Label, NewColl}`
   `no_requests`
 """.
-receive_response_collection(Collection, Timeout, Delete) ->
+receive_response_collection(Collection, Timeout, Handling) ->
+    Delete =
+        case Handling of
+            delete -> true;
+            keep -> false
+        end,
     case gen_statem:receive_response(Collection, Timeout, Delete) of
         {{reply, Reply}, Label, NewColl} ->
             {got_reply, Reply, Label, NewColl};
         {{error, {Reason, _ServerRef}}, Label, NewColl} ->
-            {request_failed, Reason, Label, NewColl};
+            {request_failed, classify_reason(Reason), Label, NewColl};
         no_request ->
             no_requests
     end.

--- a/test/actions_test.gleam
+++ b/test/actions_test.gleam
@@ -7,10 +7,16 @@
 ////
 
 import eparch/state_machine
+import gleam/dynamic.{type Dynamic}
 import gleam/erlang/atom
 import gleam/erlang/process
+import gleam/int
 import gleam/list
+import gleam/string
 import gleeunit/should
+
+@external(erlang, "sys", "get_status")
+fn sys_get_status(pid: process.Pid) -> Dynamic
 
 // STOP
 type StopState {
@@ -461,9 +467,9 @@ pub fn send_request_returns_reply_test() {
     |> state_machine.on_event(reqid_handler)
     |> state_machine.start
 
-  let req: state_machine.ReqId(Int) =
+  let request: state_machine.RequestId(Int) =
     state_machine.send_request(machine.data, GetCounter)
-  let assert Ok(count) = state_machine.receive_response(req, 1000)
+  let assert Ok(count) = state_machine.receive_response(request, 1000)
   count |> should.equal(0)
 }
 
@@ -476,45 +482,53 @@ pub fn send_request_sees_latest_state_test() {
   process.send(machine.data, Increment)
   process.send(machine.data, Increment)
 
-  let req: state_machine.ReqId(Int) =
+  let request: state_machine.RequestId(Int) =
     state_machine.send_request(machine.data, GetCounter)
-  let assert Ok(count) = state_machine.receive_response(req, 1000)
+  let assert Ok(count) = state_machine.receive_response(request, 1000)
   count |> should.equal(2)
 }
 
-pub fn reqids_size_reflects_pending_requests_test() {
+pub fn request_ids_size_reflects_pending_requests_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ReqRunning, initial_data: 0)
     |> state_machine.on_event(reqid_handler)
     |> state_machine.start
 
-  let coll: state_machine.ReqIdCollection(String, Int) =
-    state_machine.reqids_new()
-  state_machine.reqids_size(coll) |> should.equal(0)
+  let collection: state_machine.RequestIdCollection(String, Int) =
+    state_machine.request_ids_new()
+  state_machine.request_ids_size(collection) |> should.equal(0)
 
-  let coll =
+  let collection =
     state_machine.send_request_to_collection(
       machine.data,
       GetCounter,
       "first",
-      coll,
+      collection,
     )
-  state_machine.reqids_size(coll) |> should.equal(1)
+  state_machine.request_ids_size(collection) |> should.equal(1)
 
-  let coll =
+  let collection =
     state_machine.send_request_to_collection(
       machine.data,
       GetCounter,
       "second",
-      coll,
+      collection,
     )
-  state_machine.reqids_size(coll) |> should.equal(2)
+  state_machine.request_ids_size(collection) |> should.equal(2)
 
-  let assert state_machine.GotReply(_, _, coll) =
-    state_machine.receive_response_collection(coll, 1000, True)
-  let assert state_machine.GotReply(_, _, coll) =
-    state_machine.receive_response_collection(coll, 1000, True)
-  state_machine.reqids_size(coll) |> should.equal(0)
+  let assert state_machine.GotReply(_, _, collection) =
+    state_machine.receive_response_collection(
+      collection,
+      1000,
+      state_machine.Delete,
+    )
+  let assert state_machine.GotReply(_, _, collection) =
+    state_machine.receive_response_collection(
+      collection,
+      1000,
+      state_machine.Delete,
+    )
+  state_machine.request_ids_size(collection) |> should.equal(0)
 }
 
 pub fn send_request_to_collection_delivers_both_replies_test() {
@@ -523,79 +537,164 @@ pub fn send_request_to_collection_delivers_both_replies_test() {
     |> state_machine.on_event(reqid_handler)
     |> state_machine.start
 
-  let coll: state_machine.ReqIdCollection(String, Int) =
-    state_machine.reqids_new()
-  let coll =
+  let collection: state_machine.RequestIdCollection(String, Int) =
+    state_machine.request_ids_new()
+  let collection =
     state_machine.send_request_to_collection(
       machine.data,
       GetCounter,
       "a",
-      coll,
+      collection,
     )
-  let coll =
+  let collection =
     state_machine.send_request_to_collection(
       machine.data,
       GetCounter,
       "b",
-      coll,
+      collection,
     )
 
-  let assert state_machine.GotReply(v1, _l1, coll) =
-    state_machine.receive_response_collection(coll, 1000, True)
-  let assert state_machine.GotReply(v2, _l2, _) =
-    state_machine.receive_response_collection(coll, 1000, True)
+  let assert state_machine.GotReply(value1, _label1, collection) =
+    state_machine.receive_response_collection(
+      collection,
+      1000,
+      state_machine.Delete,
+    )
+  let assert state_machine.GotReply(value2, _label2, _) =
+    state_machine.receive_response_collection(
+      collection,
+      1000,
+      state_machine.Delete,
+    )
 
-  v1 |> should.equal(42)
-  v2 |> should.equal(42)
+  value1 |> should.equal(42)
+  value2 |> should.equal(42)
 }
 
-pub fn reqids_to_list_contains_all_entries_test() {
+pub fn request_ids_to_list_contains_all_entries_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ReqRunning, initial_data: 0)
     |> state_machine.on_event(reqid_handler)
     |> state_machine.start
 
-  let coll: state_machine.ReqIdCollection(String, Int) =
-    state_machine.reqids_new()
-  let coll =
+  let collection: state_machine.RequestIdCollection(String, Int) =
+    state_machine.request_ids_new()
+  let collection =
     state_machine.send_request_to_collection(
       machine.data,
       GetCounter,
       "x",
-      coll,
+      collection,
     )
-  let coll =
+  let collection =
     state_machine.send_request_to_collection(
       machine.data,
       GetCounter,
       "y",
-      coll,
+      collection,
     )
 
-  let entries = state_machine.reqids_to_list(coll)
+  let entries = state_machine.request_ids_to_list(collection)
   list.length(entries) |> should.equal(2)
 
-  let assert state_machine.GotReply(_, _, coll) =
-    state_machine.receive_response_collection(coll, 1000, True)
+  let assert state_machine.GotReply(_, _, collection) =
+    state_machine.receive_response_collection(
+      collection,
+      1000,
+      state_machine.Delete,
+    )
   let assert state_machine.GotReply(_, _, _) =
-    state_machine.receive_response_collection(coll, 1000, True)
+    state_machine.receive_response_collection(
+      collection,
+      1000,
+      state_machine.Delete,
+    )
 }
 
-pub fn reqids_add_manually_adds_to_collection_test() {
+pub fn request_ids_add_manually_adds_to_collection_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ReqRunning, initial_data: 7)
     |> state_machine.on_event(reqid_handler)
     |> state_machine.start
 
-  let req: state_machine.ReqId(Int) =
+  let request: state_machine.RequestId(Int) =
     state_machine.send_request(machine.data, GetCounter)
-  let coll: state_machine.ReqIdCollection(String, Int) =
-    state_machine.reqids_new()
-  let coll = state_machine.reqids_add(req_id: req, label: "manual", to: coll)
-  state_machine.reqids_size(coll) |> should.equal(1)
+  let collection: state_machine.RequestIdCollection(String, Int) =
+    state_machine.request_ids_new()
+  let collection =
+    state_machine.request_ids_add(
+      request_id: request,
+      label: "manual",
+      to: collection,
+    )
+  state_machine.request_ids_size(collection) |> should.equal(1)
 
-  let assert state_machine.GotReply(val, label, _) =
-    state_machine.receive_response_collection(coll, 1000, True)
-  val |> should.equal(7)
+  let assert state_machine.GotReply(value, label, _) =
+    state_machine.receive_response_collection(
+      collection,
+      1000,
+      state_machine.Delete,
+    )
+  value |> should.equal(7)
   label |> should.equal("manual")
+}
+
+// ON FORMAT STATUS
+type FmtState {
+  FmtIdle
+  FmtReady
+}
+
+type FmtMsg {
+  FmtGoReady
+}
+
+type FmtData {
+  FmtSecret(value: Int)
+  FmtRedacted(label: String)
+}
+
+fn fmt_handler(
+  event: state_machine.Event(FmtState, FmtMsg, Nil),
+  _state: FmtState,
+  data: FmtData,
+) -> state_machine.Step(FmtState, FmtData, FmtMsg, Nil) {
+  case event {
+    state_machine.Info(FmtGoReady) ->
+      state_machine.next_state(FmtReady, data, [])
+    _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn on_format_status_overrides_data_in_status_report_test() {
+  let assert Ok(machine) =
+    state_machine.new(
+      initial_state: FmtIdle,
+      initial_data: FmtSecret(value: 42),
+    )
+    |> state_machine.on_event(fmt_handler)
+    |> state_machine.on_format_status(fn(status) {
+      let label = case status.data {
+        FmtSecret(value: v) -> "FORMATTED:" <> int.to_string(v)
+        FmtRedacted(label: l) -> l
+      }
+      state_machine.Status(..status, data: FmtRedacted(label: label))
+    })
+    |> state_machine.start
+
+  let status = sys_get_status(machine.pid)
+  string.inspect(status)
+  |> string.contains("FORMATTED:42")
+  |> should.equal(True)
+}
+
+pub fn machine_without_format_status_still_appears_in_status_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: FmtIdle, initial_data: FmtSecret(value: 0))
+    |> state_machine.on_event(fmt_handler)
+    |> state_machine.start
+
+  // Should not crash; sys:get_status returns a non-empty term.
+  let _ = sys_get_status(machine.pid)
+  Nil
 }


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes in this PR. -->

## Related Issue

<!-- Link to the issue this PR addresses, if any. -->
<!-- Use "Closes #123" to auto-close the issue on merge. -->

- Closes #28
- Minor refactors so we stay true to the [Gleam conventions](https://gleam.run/documentation/conventions-patterns-and-anti-patterns/).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `gleam format` run
