### PR TITLE
feat: add timeouts

### DIFF
--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -169,6 +169,22 @@ pub type Action(message, reply) {
   /// Set a generic named timeout
   GenericTimeout(name: String, milliseconds: Int)
 
+  /// Cancel the running state timeout before it fires.
+  /// Since OTP 22.1.
+  CancelStateTimeout
+
+  /// Cancel a running named generic timeout before it fires.
+  /// Since OTP 22.1.
+  CancelGenericTimeout(name: String)
+
+  /// Update the payload delivered when the state timeout fires,
+  /// without restarting the timer. Since OTP 22.1.
+  UpdateStateTimeout(content: message)
+
+  /// Update the payload delivered when a named generic timeout fires,
+  /// without restarting the timer. Since OTP 22.1.
+  UpdateGenericTimeout(name: String, content: message)
+
   /// Change the gen_statem callback module to `module`.
   /// The new module receives the internal `#gleam_statem` record as its data,
   /// use only for Erlang interop with modules that understand eparch's internals.
@@ -590,6 +606,33 @@ pub fn generic_timeout(
   milliseconds: Int,
 ) -> Action(message, reply) {
   GenericTimeout(name:, milliseconds:)
+}
+
+/// Cancel the running state timeout before it fires.
+///
+pub fn cancel_state_timeout() -> Action(message, reply) {
+  CancelStateTimeout
+}
+
+/// Cancel a running named generic timeout before it fires.
+///
+pub fn cancel_generic_timeout(name: String) -> Action(message, reply) {
+  CancelGenericTimeout(name:)
+}
+
+/// Update the payload of the running state timeout without restarting the timer.
+///
+pub fn update_state_timeout(content: message) -> Action(message, reply) {
+  UpdateStateTimeout(content: content)
+}
+
+/// Update the payload of a running named generic timeout without restarting the timer.
+///
+pub fn update_generic_timeout(
+  name: String,
+  content: message,
+) -> Action(message, reply) {
+  UpdateGenericTimeout(name: name, content: content)
 }
 
 /// Create a ChangeCallbackModule action.

--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -632,7 +632,7 @@ pub fn update_generic_timeout(
   name: String,
   content: message,
 ) -> Action(message, reply) {
-  UpdateGenericTimeout(name: name, content: content)
+  UpdateGenericTimeout(name:, content:)
 }
 
 /// Create a ChangeCallbackModule action.

--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -623,7 +623,7 @@ pub fn cancel_generic_timeout(name: String) -> Action(message, reply) {
 /// Update the payload of the running state timeout without restarting the timer.
 ///
 pub fn update_state_timeout(content: message) -> Action(message, reply) {
-  UpdateStateTimeout(content: content)
+  UpdateStateTimeout(content:)
 }
 
 /// Update the payload of a running named generic timeout without restarting the timer.

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -483,6 +483,14 @@ convert_action_to_erlang(Action) ->
             {state_timeout, Milliseconds, timeout};
         {generic_timeout, Name, Milliseconds} ->
             {{timeout, Name}, Milliseconds, timeout};
+        cancel_state_timeout ->
+            {state_timeout, cancel};
+        {cancel_generic_timeout, Name} ->
+            {{timeout, Name}, cancel};
+        {update_state_timeout, Content} ->
+            {state_timeout, update, Content};
+        {update_generic_timeout, Name, Content} ->
+            {{timeout, Name}, update, Content};
         {change_callback_module, Module} ->
             {change_callback_module, Module};
         {push_callback_module, Module} ->

--- a/test/actions_test.gleam
+++ b/test/actions_test.gleam
@@ -293,6 +293,168 @@ pub fn generic_timeout_fires_after_interval_test() {
   s |> should.equal(GtTriggered)
 }
 
+type CstState {
+  CstIdle
+  CstActive
+  CstTimedOut
+}
+
+type CstMsg {
+  CstActivate
+  CstCancel
+  CstGetState(reply_with: process.Subject(CstState))
+}
+
+fn cancel_state_timeout_handler(
+  event: state_machine.Event(CstState, CstMsg, Nil),
+  state: CstState,
+  data: Nil,
+) -> state_machine.Step(CstState, Nil, CstMsg, Nil) {
+  case event, state {
+    state_machine.Info(CstActivate), CstIdle ->
+      state_machine.next_state(CstActive, data, [
+        state_machine.StateTimeout(5000),
+      ])
+
+    state_machine.Info(CstCancel), CstActive ->
+      state_machine.keep_state(data, [state_machine.cancel_state_timeout()])
+
+    state_machine.Timeout(state_machine.StateTimeoutType), CstActive ->
+      state_machine.next_state(CstTimedOut, data, [])
+
+    state_machine.Info(CstGetState(reply_with: reply_sub)), _ -> {
+      process.send(reply_sub, state)
+      state_machine.keep_state(data, [])
+    }
+
+    _, _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn cancel_state_timeout_prevents_fire_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: CstIdle, initial_data: Nil)
+    |> state_machine.on_event(cancel_state_timeout_handler)
+    |> state_machine.start
+
+  process.send(machine.data, CstActivate)
+  process.send(machine.data, CstCancel)
+  process.sleep(30)
+
+  let reply_sub = process.new_subject()
+  process.send(machine.data, CstGetState(reply_with: reply_sub))
+  let assert Ok(s) = process.receive(reply_sub, 1000)
+  s |> should.equal(CstActive)
+}
+
+type CgtState {
+  CgtWaiting
+  CgtTriggered
+}
+
+type CgtMsg {
+  CgtArm
+  CgtCancel
+  CgtGetState(reply_with: process.Subject(CgtState))
+}
+
+fn cancel_generic_timeout_handler(
+  event: state_machine.Event(CgtState, CgtMsg, Nil),
+  state: CgtState,
+  data: Nil,
+) -> state_machine.Step(CgtState, Nil, CgtMsg, Nil) {
+  case event, state {
+    state_machine.Info(CgtArm), CgtWaiting ->
+      state_machine.keep_state(data, [
+        state_machine.GenericTimeout("tick", 5000),
+      ])
+
+    state_machine.Info(CgtCancel), CgtWaiting ->
+      state_machine.keep_state(data, [
+        state_machine.cancel_generic_timeout("tick"),
+      ])
+
+    state_machine.Timeout(state_machine.GenericTimeoutType("tick")), CgtWaiting ->
+      state_machine.next_state(CgtTriggered, data, [])
+
+    state_machine.Info(CgtGetState(reply_with: reply_sub)), _ -> {
+      process.send(reply_sub, state)
+      state_machine.keep_state(data, [])
+    }
+
+    _, _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn cancel_generic_timeout_prevents_fire_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: CgtWaiting, initial_data: Nil)
+    |> state_machine.on_event(cancel_generic_timeout_handler)
+    |> state_machine.start
+
+  process.send(machine.data, CgtArm)
+  process.send(machine.data, CgtCancel)
+  process.sleep(30)
+
+  let reply_sub = process.new_subject()
+  process.send(machine.data, CgtGetState(reply_with: reply_sub))
+  let assert Ok(s) = process.receive(reply_sub, 1000)
+  s |> should.equal(CgtWaiting)
+}
+
+type UstState {
+  UstWaiting
+  UstFired
+}
+
+type UstMsg {
+  UstArm
+  UstUpdate
+  UstGetState(reply_with: process.Subject(UstState))
+}
+
+fn update_state_timeout_handler(
+  event: state_machine.Event(UstState, UstMsg, Nil),
+  state: UstState,
+  data: Nil,
+) -> state_machine.Step(UstState, Nil, UstMsg, Nil) {
+  case event, state {
+    state_machine.Info(UstArm), UstWaiting ->
+      state_machine.keep_state(data, [state_machine.StateTimeout(200)])
+
+    state_machine.Info(UstUpdate), UstWaiting ->
+      state_machine.keep_state(data, [
+        state_machine.update_state_timeout(UstUpdate),
+      ])
+
+    state_machine.Timeout(state_machine.StateTimeoutType), UstWaiting ->
+      state_machine.next_state(UstFired, data, [])
+
+    state_machine.Info(UstGetState(reply_with: reply_sub)), _ -> {
+      process.send(reply_sub, state)
+      state_machine.keep_state(data, [])
+    }
+
+    _, _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn update_state_timeout_fires_without_restart_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: UstWaiting, initial_data: Nil)
+    |> state_machine.on_event(update_state_timeout_handler)
+    |> state_machine.start
+
+  process.send(machine.data, UstArm)
+  process.send(machine.data, UstUpdate)
+  process.sleep(300)
+
+  let reply_sub = process.new_subject()
+  process.send(machine.data, UstGetState(reply_with: reply_sub))
+  let assert Ok(s) = process.receive(reply_sub, 1000)
+  s |> should.equal(UstFired)
+}
+
 // CAST
 //
 // 1. state_machine.cast delivers `Cast(msg)`.


### PR DESCRIPTION
## Description

Adds support for cancelling and updating the payload of running timeouts in `gen_statem`, as specified by OTP >= 22.1.

**New `Action` variants:**
- `CancelStateTimeout`: cancels the running state timeout
- `CancelGenericTimeout(name: String)`: cancels a running named generic timeout
- `UpdateStateTimeout(content: message)`: updates the payload delivered when the state timeout fires, without restarting the timer
- `UpdateGenericTimeout(name: String, content: message)`: same for a named generic timeout

**New helper functions:** `cancel_state_timeout/0`, `cancel_generic_timeout/1`, `update_state_timeout/1`, `update_generic_timeout/2`

The FFI layer (`statem_ffi.erl`) maps each new action to the corresponding OTP tuple: `{state_timeout, cancel}`, `{{timeout, Name}, cancel}`, `{state_timeout, update, Content}`, `{{timeout, Name}, update, Content}`.

## Related Issue

[Closes #35](https://github.com/byzantine-systems/eparch/issues/35)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated (if applicable)
- [x] `gleam format` run
