### PR TITLE
feat: add support for hibernate_after

### DIFF
--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -429,6 +429,29 @@ pub fn named(
   Builder(..builder, name: Some(name))
 }
 
+// TODO: reject negative `milliseconds` values; gen_statem requires
+// `timeout()` (0..infinity) and will crash at start otherwise.
+
+/// Configure the [`hibernate_after`](https://www.erlang.org/doc/apps/stdlib/gen_statem.html#start_link/3)
+/// start option.
+///
+/// When the state machine has been idle for at least `milliseconds`, the
+/// process hibernates (calls `proc_lib:hibernate/3`), trading a small wake-up
+/// cost for reduced memory footprint until the next event arrives. Useful for
+/// long-lived machines that spend most of their time waiting.
+///
+/// This is independent of the per-callback `Hibernate` action, which forces
+/// hibernation immediately after a single callback returns.
+///
+/// ## Example
+///
+/// ```gleam
+/// state_machine.new(initial_state: Idle, initial_data: 0)
+/// |> state_machine.hibernate_after(60_000)
+/// |> state_machine.on_event(handle_event)
+/// |> state_machine.start
+/// ```
+///
 pub fn hibernate_after(
   builder: Builder(state, data, message, return, reply),
   milliseconds: Int,

--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -38,6 +38,7 @@ pub opaque type Builder(state, data, message, return, reply) {
     state_enter: StateEnter,
     initialisation_timeout: Int,
     name: Option(process.Name(message)),
+    hibernate_after: Option(Int),
     on_code_change: Option(fn(data) -> data),
     on_format_status: Option(
       fn(Status(state, data, message, reply)) ->
@@ -344,6 +345,7 @@ pub fn new(
     state_enter: StateEnterDisabled,
     initialisation_timeout: 1000,
     name: None,
+    hibernate_after: None,
     on_code_change: None,
     on_format_status: None,
   )
@@ -425,6 +427,13 @@ pub fn named(
   name: process.Name(message),
 ) -> Builder(state, data, message, return, reply) {
   Builder(..builder, name: Some(name))
+}
+
+pub fn hibernate_after(
+  builder: Builder(state, data, message, return, reply),
+  milliseconds: Int,
+) -> Builder(state, data, message, return, reply) {
+  Builder(..builder, hibernate_after: Some(milliseconds))
 }
 
 /// Provide a migration function called during hot-code upgrades.
@@ -517,6 +526,7 @@ pub fn start(
     state_enter:,
     initialisation_timeout:,
     name:,
+    hibernate_after:,
     on_code_change:,
     on_format_status:,
   ) = builder
@@ -527,6 +537,7 @@ pub fn start(
     state_enter,
     initialisation_timeout,
     name,
+    hibernate_after,
     on_code_change,
     on_format_status,
   )
@@ -541,6 +552,7 @@ fn do_start(
   state_enter: StateEnter,
   initialisation_timeout: Int,
   name: Option(process.Name(message)),
+  hibernate_after: Option(Int),
   on_code_change: Option(fn(data) -> data),
   on_format_status: Option(
     fn(Status(state, data, message, reply)) ->

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -7,7 +7,7 @@ gen_statem behavior callbacks and Gleam's type-safe API.
 -behaviour(gen_statem).
 
 %% Public API
--export([do_start/8, cast/2]).
+-export([do_start/9, cast/2]).
 -export([
     reqids_new/0,
     reqids_add/3,
@@ -63,7 +63,7 @@ Start a `gen_statem` process linked to the caller and return the Subject
 needed to send messages to it
 """.
 -spec do_start(
-    InitialState, InitialData, Handler, StateEnter, TimeOut, Name, OnCodeChange, OnFormatStatus
+    InitialState, InitialData, Handler, StateEnter, TimeOut, Name, HibernateAfter, OnCodeChange, OnFormatStatus
 ) ->
     Result
 when
@@ -73,11 +73,12 @@ when
     StateEnter :: state_enter_option(),
     TimeOut :: timeout(),
     Name :: process_name_option(),
+    HibernateAfter :: none | {some, non_neg_integer()},
     OnCodeChange :: any(),
     OnFormatStatus :: any(),
     Result :: any().
 do_start(
-    InitialState, InitialData, Handler, StateEnter, Timeout, Name, OnCodeChange, OnFormatStatus
+    InitialState, InitialData, Handler, StateEnter, Timeout, Name, HibernateAfter, OnCodeChange, OnFormatStatus
 ) ->
     %% Ack channel: a unique reference the child process will use to
     %% send us the Subject it creates in init/1.
@@ -88,10 +89,17 @@ do_start(
         {init_args, InitialState, InitialData, Handler, StateEnter, Parent, AckTag, Name,
             OnCodeChange, OnFormatStatus},
 
+    BaseOpts = [{timeout, Timeout}],
+    Opts =
+        case HibernateAfter of
+            none -> BaseOpts;
+            {some, Ms} -> [{hibernate_after, Ms} | BaseOpts]
+        end,
+
     StartResult =
         case Name of
             none ->
-                gen_statem:start_link(?MODULE, InitArgs, [{timeout, Timeout}]);
+                gen_statem:start_link(?MODULE, InitArgs, Opts);
             {some, ProcessName} ->
                 gen_statem:start_link(
                     %% TODO: Change this to support other formats
@@ -99,7 +107,7 @@ do_start(
                     {local, ProcessName},
                     ?MODULE,
                     InitArgs,
-                    [{timeout, Timeout}]
+                    Opts
                 )
         end,
 

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -63,7 +63,15 @@ Start a `gen_statem` process linked to the caller and return the Subject
 needed to send messages to it
 """.
 -spec do_start(
-    InitialState, InitialData, Handler, StateEnter, TimeOut, Name, HibernateAfter, OnCodeChange, OnFormatStatus
+    InitialState,
+    InitialData,
+    Handler,
+    StateEnter,
+    TimeOut,
+    Name,
+    HibernateAfter,
+    OnCodeChange,
+    OnFormatStatus
 ) ->
     Result
 when
@@ -78,7 +86,15 @@ when
     OnFormatStatus :: any(),
     Result :: any().
 do_start(
-    InitialState, InitialData, Handler, StateEnter, Timeout, Name, HibernateAfter, OnCodeChange, OnFormatStatus
+    InitialState,
+    InitialData,
+    Handler,
+    StateEnter,
+    Timeout,
+    Name,
+    HibernateAfter,
+    OnCodeChange,
+    OnFormatStatus
 ) ->
     %% Ack channel: a unique reference the child process will use to
     %% send us the Subject it creates in init/1.

--- a/test/actions_test.gleam
+++ b/test/actions_test.gleam
@@ -18,6 +18,9 @@ import gleeunit/should
 @external(erlang, "sys", "get_status")
 fn sys_get_status(pid: process.Pid) -> Dynamic
 
+@external(erlang, "erlang", "process_info")
+fn process_info(pid: process.Pid, key: atom.Atom) -> Dynamic
+
 // STOP
 type StopState {
   StopRunning
@@ -842,6 +845,70 @@ pub fn stop_and_reply_sends_reply_before_stopping_test() {
 
   let assert Ok(down) = process.selector_receive(sel, 1000)
   down.reason |> should.equal(process.Normal)
+}
+
+// HIBERNATE AFTER
+type HibState {
+  HibIdle
+}
+
+type HibMsg {
+  HibPing(reply_with: process.Subject(String))
+}
+
+fn hibernate_after_handler(
+  event: state_machine.Event(HibState, HibMsg, Nil),
+  _state: HibState,
+  data: Nil,
+) -> state_machine.Step(HibState, Nil, HibMsg, Nil) {
+  case event {
+    state_machine.Info(HibPing(reply_with: reply_sub)) -> {
+      process.send(reply_sub, "pong")
+      state_machine.keep_state(data, [])
+    }
+    _ -> state_machine.keep_state(data, [])
+  }
+}
+
+// Configures a 10ms timer, sleeps 50ms, checks process_info(pid, current_function) 
+// reports gen_statem:loop_hibernate/3, then verifies the machine still responds
+// to a message after waking.
+pub fn hibernate_after_puts_idle_process_into_hibernation_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: HibIdle, initial_data: Nil)
+    |> state_machine.hibernate_after(10)
+    |> state_machine.on_event(hibernate_after_handler)
+    |> state_machine.start
+
+  // Wait long enough for the idle timer to fire. When hibernating, the
+  // process's current_function is gen_statem:loop_hibernate/3.
+  process.sleep(50)
+
+  let info = process_info(machine.pid, atom.create("current_function"))
+  string.inspect(info)
+  |> string.contains("Hibernate")
+  |> should.equal(True)
+
+  // Sending a message wakes the process; the handler still runs.
+  let reply_sub = process.new_subject()
+  process.send(machine.data, HibPing(reply_with: reply_sub))
+  let assert Ok(reply) = process.receive(reply_sub, 1000)
+  reply |> should.equal("pong")
+}
+
+// Negative control confirming the option is actually doing the work.
+pub fn machine_without_hibernate_after_does_not_hibernate_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: HibIdle, initial_data: Nil)
+    |> state_machine.on_event(hibernate_after_handler)
+    |> state_machine.start
+
+  process.sleep(50)
+
+  let info = process_info(machine.pid, atom.create("current_function"))
+  string.inspect(info)
+  |> string.contains("Hibernate")
+  |> should.equal(False)
 }
 
 // ON FORMAT STATUS


### PR DESCRIPTION
## Description

Exposes `gen_statem`'s `hibernate_after` start option through the Gleam builder pattern.

When set, the process automatically hibernates after being idle for the given number of milliseconds, reducing its memory footprint. It wakes normally on the next message. Maps to OTP's `{hibernate_after, Ms}` start option.

**New builder field and function:**

```gleam
state_machine.new(initial_state: Idle, initial_data: data)
|> state_machine.hibernate_after(5000)
|> state_machine.on_event(handle_event)
|> state_machine.start
```

## Related Issue

- Closes #34

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `gleam format` run
