### PR TITLE
feat: adding wrappers

### DIFF
--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -1023,3 +1023,63 @@ pub fn receive_response_collection(
   timeout: Int,
   handling: ResponseHandling,
 ) -> CollectionResponse(reply, label)
+
+/// Stop a running state machine from the client with reason `normal`.
+///
+@external(erlang, "statem_ffi", "stop_server")
+pub fn stop_server(subject: Subject(message)) -> Nil
+
+/// Stop a running state machine from the client with a custom reason and timeout (ms).
+///
+@external(erlang, "statem_ffi", "stop_server_with")
+pub fn stop_server_with(
+  subject: Subject(message),
+  reason: ExitReason,
+  timeout: Int,
+) -> Nil
+
+/// Send a reply to a caller from outside the state machine callback.
+///
+/// Unlike the `Reply` action (which replies inside the callback), this can
+/// be called from any process that holds a `From` value.
+///
+@external(erlang, "statem_ffi", "send_reply")
+pub fn send_reply(from: From(reply), response: reply) -> Nil
+
+/// Send multiple replies at once from outside the callback.
+///
+@external(erlang, "statem_ffi", "send_replies")
+pub fn send_replies(replies: List(#(From(reply), reply))) -> Nil
+
+/// Block indefinitely until a reply arrives for a `RequestId`.
+///
+/// Since OTP 23.
+///
+@external(erlang, "statem_ffi", "wait_response")
+pub fn wait_response(
+  request_id: RequestId(reply),
+) -> Result(reply, ReceiveError)
+
+/// Block until a reply arrives or the timeout (ms) expires.
+///
+/// Since OTP 23.
+///
+@external(erlang, "statem_ffi", "wait_response_timeout")
+pub fn wait_response_timeout(
+  request_id: RequestId(reply),
+  timeout: Int,
+) -> Result(reply, ReceiveError)
+
+/// Check whether a received message is the reply for a `RequestId`.
+///
+/// - `Ok(Some(reply))` — the message is the reply
+/// - `Ok(None)` — the message is unrelated to this request
+/// - `Error(ReceiveError)` — the server crashed
+///
+/// Since OTP 23.
+///
+@external(erlang, "statem_ffi", "check_response")
+pub fn check_response(
+  message: Dynamic,
+  request_id: RequestId(reply),
+) -> Result(Option(reply), ReceiveError)

--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -1060,6 +1060,17 @@ pub fn wait_response(
   request_id: RequestId(reply),
 ) -> Result(reply, ReceiveError)
 
+/// Block indefinitely until the reply to a `RequestId` arrives, using
+/// `gen_statem:receive_response/1`. Equivalent to `receive_response` with
+/// no timeout, complementing the timeout-bounded `receive_response/2`.
+///
+/// Requires Erlang/OTP 24 or later.
+///
+@external(erlang, "statem_ffi", "receive_response_blocking")
+pub fn receive_response_blocking(
+  request_id: RequestId(reply),
+) -> Result(reply, ReceiveError)
+
 /// Block until a reply arrives or the timeout (ms) expires.
 ///
 /// Since OTP 23.
@@ -1072,9 +1083,9 @@ pub fn wait_response_timeout(
 
 /// Check whether a received message is the reply for a `RequestId`.
 ///
-/// - `Ok(Some(reply))` — the message is the reply
-/// - `Ok(None)` — the message is unrelated to this request
-/// - `Error(ReceiveError)` — the server crashed
+/// - `Ok(Some(reply))`: the message is the reply
+/// - `Ok(None)`: the message is unrelated to this request
+/// - `Error(ReceiveError)`: the server crashed
 ///
 /// Since OTP 23.
 ///

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -9,6 +9,12 @@ gen_statem behavior callbacks and Gleam's type-safe API.
 %% Public API
 -export([do_start/9, cast/2]).
 -export([
+    stop_server/1, stop_server_with/3,
+    send_reply/2, send_replies/1,
+    wait_response/1, wait_response_timeout/2,
+    check_response/2
+]).
+-export([
     reqids_new/0,
     reqids_add/3,
     reqids_size/1,
@@ -555,6 +561,13 @@ convert_action_to_erlang(Action) ->
             pop_callback_module
     end.
 
+subject_to_pid({subject, Pid, _Tag}) -> Pid;
+subject_to_pid({named_subject, Name}) ->
+    case erlang:whereis(Name) of
+        Pid when is_pid(Pid) -> Pid;
+        undefined -> error({noproc, Name})
+    end.
+
 -doc """
 Sends an asynchronous `cast` to a running `gen_statem` process.
 
@@ -563,18 +576,57 @@ The message arrives in `handle_event/4` with `EventType=cast` and is
 converted to `Cast(Msg)` for the Gleam handler.
 """.
 cast(Subject, Msg) ->
-    Pid =
-        case Subject of
-            {subject, P, _Tag} ->
-                P;
-            {named_subject, Name} ->
-                case erlang:whereis(Name) of
-                    P when is_pid(P) -> P;
-                    undefined -> error({noproc, Name})
-                end
-        end,
-    gen_statem:cast(Pid, Msg),
+    gen_statem:cast(subject_to_pid(Subject), Msg),
     nil.
+
+-doc "Stop a running state machine with reason `normal`.".
+stop_server(Subject) ->
+    gen_statem:stop(subject_to_pid(Subject)),
+    nil.
+
+-doc "Stop a running state machine with a custom reason and timeout (ms).".
+stop_server_with(Subject, Reason, Timeout) ->
+    gen_statem:stop(subject_to_pid(Subject), convert_exit_reason(Reason), Timeout),
+    nil.
+
+-doc "Send a reply to a caller from outside the state machine callback.".
+send_reply(From, Reply) ->
+    gen_statem:reply(From, Reply),
+    nil.
+
+-doc """
+Send multiple replies at once.
+Gleam's #(From, Reply) tuples are already {From, Reply} in Erlang.
+""".
+send_replies(Replies) ->
+    gen_statem:reply(Replies),
+    nil.
+
+-doc "Block indefinitely until a reply arrives. Since OTP 23.".
+wait_response(ReqId) ->
+    case gen_statem:wait_response(ReqId) of
+        {reply, Reply} -> {ok, Reply};
+        {error, {Reason, _}} -> {error, {request_crashed, classify_reason(Reason)}}
+    end.
+
+-doc "Block until a reply arrives or the timeout (ms) expires. Since OTP 23.".
+wait_response_timeout(ReqId, Timeout) ->
+    case gen_statem:wait_response(ReqId, Timeout) of
+        {reply, Reply} -> {ok, Reply};
+        timeout -> {error, receive_timeout};
+        {error, {Reason, _}} -> {error, {request_crashed, classify_reason(Reason)}}
+    end.
+
+-doc """
+Check if a received message is the reply for a request. Since OTP 23.
+Returns {ok, {some, Reply}}, {ok, none}, or {error, StopReason}.
+""".
+check_response(Msg, ReqId) ->
+    case gen_statem:check_response(Msg, ReqId) of
+        {reply, Reply} -> {ok, {some, Reply}};
+        no_reply -> {ok, none};
+        {error, {Reason, _}} -> {error, {request_crashed, classify_reason(Reason)}}
+    end.
 
 %%%===================================================================
 %%% reqids API — OTP 25.0+

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -9,10 +9,14 @@ gen_statem behavior callbacks and Gleam's type-safe API.
 %% Public API
 -export([do_start/9, cast/2]).
 -export([
-    stop_server/1, stop_server_with/3,
-    send_reply/2, send_replies/1,
-    wait_response/1, wait_response_timeout/2,
-    check_response/2
+    stop_server/1,
+    stop_server_with/3,
+    send_reply/2,
+    send_replies/1,
+    wait_response/1,
+    wait_response_timeout/2,
+    check_response/2,
+    receive_response_blocking/1
 ]).
 -export([
     reqids_new/0,
@@ -561,7 +565,8 @@ convert_action_to_erlang(Action) ->
             pop_callback_module
     end.
 
-subject_to_pid({subject, Pid, _Tag}) -> Pid;
+subject_to_pid({subject, Pid, _Tag}) ->
+    Pid;
 subject_to_pid({named_subject, Name}) ->
     case erlang:whereis(Name) of
         Pid when is_pid(Pid) -> Pid;
@@ -596,10 +601,12 @@ send_reply(From, Reply) ->
 
 -doc """
 Send multiple replies at once.
-Gleam's #(From, Reply) tuples are already {From, Reply} in Erlang.
+Gleam's #(From, Reply) tuples are {From, Reply} in Erlang and must be
+converted to gen_statem reply actions {reply, From, Reply}.
 """.
 send_replies(Replies) ->
-    gen_statem:reply(Replies),
+    Actions = [{reply, F, R} || {F, R} <- Replies],
+    gen_statem:reply(Actions),
     nil.
 
 -doc "Block indefinitely until a reply arrives. Since OTP 23.".
@@ -615,6 +622,13 @@ wait_response_timeout(ReqId, Timeout) ->
         {reply, Reply} -> {ok, Reply};
         timeout -> {error, receive_timeout};
         {error, {Reason, _}} -> {error, {request_crashed, classify_reason(Reason)}}
+    end.
+
+-doc "Block indefinitely waiting for the reply to a single ReqId. Since OTP 24.".
+receive_response_blocking(ReqId) ->
+    case gen_statem:receive_response(ReqId) of
+        {reply, Reply} -> {ok, Reply};
+        {error, {Reason, _ServerRef}} -> {error, {request_crashed, classify_reason(Reason)}}
     end.
 
 -doc """

--- a/test/actions_test.gleam
+++ b/test/actions_test.gleam
@@ -12,6 +12,7 @@ import gleam/erlang/atom
 import gleam/erlang/process
 import gleam/int
 import gleam/list
+import gleam/option
 import gleam/string
 import gleeunit/should
 
@@ -969,4 +970,209 @@ pub fn machine_without_format_status_still_appears_in_status_test() {
   // Should not crash; sys:get_status returns a non-empty term.
   let _ = sys_get_status(machine.pid)
   Nil
+}
+
+// CLIENT API WRAPPERS (issue #32): stop_server, send_reply(s), wait_response,
+// check_response, receive_response_blocking.
+
+type ClientState {
+  ClientRunning
+}
+
+type ClientMsg {
+  CliGet
+  // CliAsk parks the caller's From in an external stash so the test process
+  // can reply with send_reply / send_replies from outside the callback.
+  CliAsk(stash: process.Subject(state_machine.From(Int)))
+  // CliNoReply intentionally leaves the call without a reply, used to drive
+  // wait_response_timeout into ReceiveTimeout.
+  CliNoReply
+}
+
+fn client_handler(
+  event: state_machine.Event(ClientState, ClientMsg, Int),
+  _state: ClientState,
+  data: Int,
+) -> state_machine.Step(ClientState, Int, ClientMsg, Int) {
+  case event {
+    state_machine.Call(from, CliGet) ->
+      state_machine.keep_state(data, [state_machine.Reply(from, data)])
+    state_machine.Call(from, CliAsk(stash)) -> {
+      process.send(stash, from)
+      state_machine.keep_state(data, [])
+    }
+    state_machine.Call(_from, CliNoReply) -> state_machine.keep_state(data, [])
+    _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn stop_server_terminates_machine_with_normal_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ClientRunning, initial_data: 0)
+    |> state_machine.on_event(client_handler)
+    |> state_machine.start
+
+  let monitor = process.monitor(machine.pid)
+  let sel =
+    process.new_selector()
+    |> process.select_specific_monitor(monitor, fn(d) { d })
+
+  state_machine.stop_server(machine.data)
+
+  let assert Ok(down) = process.selector_receive(sel, 1000)
+  down.reason |> should.equal(process.Normal)
+}
+
+pub fn stop_server_with_custom_reason_test() {
+  // gen_statem:start_link links the machine to the test process, so a
+  // non-normal exit reason propagates here and proc_lib:stop/3 also raises
+  // for non-normal reasons. Trap exits so the test process survives.
+  process.trap_exits(True)
+
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ClientRunning, initial_data: 0)
+    |> state_machine.on_event(client_handler)
+    |> state_machine.start
+
+  let monitor = process.monitor(machine.pid)
+  let sel =
+    process.new_selector()
+    |> process.select_specific_monitor(monitor, fn(d) { d })
+
+  let reason = process.Abnormal(dynamic.string("shutdown_requested"))
+  let _ =
+    process.spawn_unlinked(fn() {
+      state_machine.stop_server_with(machine.data, reason, 1000)
+    })
+
+  // The exact reason round-tripping through gleam_erlang's monitor decoder
+  // is governed by the existing convert_exit_reason/cast_exit_reason pair;
+  // here we just confirm the 3-arg call drives the machine to terminate.
+  let assert Ok(process.ProcessDown(pid: down_pid, ..)) =
+    process.selector_receive(sel, 1000)
+  down_pid |> should.equal(machine.pid)
+
+  process.flush_messages()
+  process.trap_exits(False)
+}
+
+pub fn send_reply_from_external_process_completes_call_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ClientRunning, initial_data: 0)
+    |> state_machine.on_event(client_handler)
+    |> state_machine.start
+
+  let stash: process.Subject(state_machine.From(Int)) = process.new_subject()
+  let req: state_machine.RequestId(Int) =
+    state_machine.send_request(machine.data, CliAsk(stash))
+
+  let assert Ok(from) = process.receive(stash, 1000)
+  state_machine.send_reply(from, 123)
+
+  let assert Ok(reply) = state_machine.receive_response(req, 1000)
+  reply |> should.equal(123)
+}
+
+pub fn send_replies_completes_multiple_calls_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ClientRunning, initial_data: 0)
+    |> state_machine.on_event(client_handler)
+    |> state_machine.start
+
+  let stash: process.Subject(state_machine.From(Int)) = process.new_subject()
+
+  let req1: state_machine.RequestId(Int) =
+    state_machine.send_request(machine.data, CliAsk(stash))
+  let req2: state_machine.RequestId(Int) =
+    state_machine.send_request(machine.data, CliAsk(stash))
+
+  let assert Ok(from1) = process.receive(stash, 1000)
+  let assert Ok(from2) = process.receive(stash, 1000)
+
+  state_machine.send_replies([#(from1, 1), #(from2, 2)])
+
+  let assert Ok(r1) = state_machine.receive_response(req1, 1000)
+  let assert Ok(r2) = state_machine.receive_response(req2, 1000)
+  r1 |> should.equal(1)
+  r2 |> should.equal(2)
+}
+
+pub fn wait_response_returns_reply_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ClientRunning, initial_data: 99)
+    |> state_machine.on_event(client_handler)
+    |> state_machine.start
+
+  let req: state_machine.RequestId(Int) =
+    state_machine.send_request(machine.data, CliGet)
+  let assert Ok(value) = state_machine.wait_response(req)
+  value |> should.equal(99)
+}
+
+pub fn wait_response_timeout_yields_receive_timeout_when_no_reply_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ClientRunning, initial_data: 0)
+    |> state_machine.on_event(client_handler)
+    |> state_machine.start
+
+  let req: state_machine.RequestId(Int) =
+    state_machine.send_request(machine.data, CliNoReply)
+
+  state_machine.wait_response_timeout(req, 50)
+  |> should.equal(Error(state_machine.ReceiveTimeout))
+}
+
+pub fn check_response_returns_none_for_unrelated_message_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ClientRunning, initial_data: 0)
+    |> state_machine.on_event(client_handler)
+    |> state_machine.start
+
+  let req: state_machine.RequestId(Int) =
+    state_machine.send_request(machine.data, CliGet)
+
+  // An int dynamic is not a gen_statem reply tuple.
+  let unrelated = dynamic.int(42)
+  state_machine.check_response(unrelated, req)
+  |> should.equal(Ok(option.None))
+
+  // Drain the real reply so the mailbox is clean for the next test.
+  let _ = state_machine.receive_response(req, 1000)
+}
+
+pub fn check_response_returns_some_for_matching_reply_test() {
+  process.flush_messages()
+
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ClientRunning, initial_data: 11)
+    |> state_machine.on_event(client_handler)
+    |> state_machine.start
+
+  let req: state_machine.RequestId(Int) =
+    state_machine.send_request(machine.data, CliGet)
+
+  let selector =
+    process.new_selector()
+    |> process.select_other(fn(msg) { msg })
+  let assert Ok(raw) = process.selector_receive(from: selector, within: 1000)
+
+  case state_machine.check_response(raw, req) {
+    Ok(option.Some(value)) -> value |> should.equal(11)
+    other -> {
+      string.inspect(other) |> should.equal("Ok(Some(11))")
+      Nil
+    }
+  }
+}
+
+pub fn receive_response_blocking_returns_reply_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: ClientRunning, initial_data: 7)
+    |> state_machine.on_event(client_handler)
+    |> state_machine.start
+
+  let req: state_machine.RequestId(Int) =
+    state_machine.send_request(machine.data, CliGet)
+  let assert Ok(value) = state_machine.receive_response_blocking(req)
+  value |> should.equal(7)
 }


### PR DESCRIPTION
## Description

Surfaces missing `gen_statem` client-side APIs as type-safe Gleam wrappers.

**`stop_server/1` and `stop_server_with/3`**: stop a running state machine from the client. Distinct from the existing `stop/1` which is used *inside* the callback to return a `Step`.

**`send_reply/2` and `send_replies/1`**: call `gen_statem:reply` directly from any process, not only inside the callback. Useful when a `From` is stored in the machine's data and replied to later or from a different process.

**`wait_response/1` and `wait_response_timeout/2`**: OTP 23 counterparts to the existing `receive_response/2`. `wait_response/1` blocks indefinitely; `wait_response_timeout/2` accepts an explicit millisecond timeout.

**`check_response/2`**: OTP 23. Checks whether a raw mailbox message is the reply to a given `RequestId`. Returns `Ok(Some(reply))`, `Ok(None)` (unrelated message), or `Error(ReceiveError)` (server crashed).

The FFI also extracts a `subject_to_pid/1` helper used by both `cast` and the new wrappers, removing duplicated pid-extraction logic.

## Related Issue

- Closes #32

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `gleam format` run
