### PR TITLE
feat: adding action

### DIFF
--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -161,7 +161,9 @@ pub type Action(message, reply) {
   Postpone
 
   /// Insert a new event at the front of the queue
-  NextEvent(content: message)
+  /// Inject a synthetic event of any kind that gen_statem accepts.
+  /// Mirrors gen_statem:event_type/0.
+  NextEvent(event_type: NextEventType(reply), content: message)
 
   /// Set a state timeout (canceled on state change)
   StateTimeout(milliseconds: Int)

--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -205,10 +205,11 @@ pub type TimeoutType {
   GenericTimeoutType(name: String)
 }
 
-/// The event type used when injecting synthetic events with `inject_event`.
-///
-pub type SyntheticEventType(reply) {
-  /// Delivered as an internal event (same as `NextEvent`)
+/// Mirrors gen_statem's event_type/0 so a single NextEvent can inject any
+/// kind of synthetic event into the state machine.
+/// https://www.erlang.org/doc/apps/stdlib/gen_statem.html#t:event_type/0
+pub type NextEventType(reply) {
+  /// Delivered as an internal event
   InternalEvent
   /// Delivered as a cast event
   CastEvent

--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -175,7 +175,8 @@ pub type Action(message, reply) {
   /// Conditionally postpone the current event.
   /// `PostponeIf(True)` is equivalent to `Postpone`.
   /// `PostponeIf(False)` explicitly opts out of postponement.
-  PostponeIf(value: Bool)
+  /// Postpone this event until after a state change.
+  Postpone
 
   /// Inject a synthetic event with a specific event type.
   /// Unlike `NextEvent` (always internal), this lets you inject cast,

--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -169,6 +169,19 @@ pub type Action(message, reply) {
   /// Set a generic named timeout
   GenericTimeout(name: String, milliseconds: Int)
 
+  /// Hibernate the process after this callback returns.
+  Hibernate
+
+  /// Conditionally postpone the current event.
+  /// `PostponeIf(True)` is equivalent to `Postpone`.
+  /// `PostponeIf(False)` explicitly opts out of postponement.
+  PostponeIf(value: Bool)
+
+  /// Inject a synthetic event with a specific event type.
+  /// Unlike `NextEvent` (always internal), this lets you inject cast,
+  /// info, or call events into the event queue.
+  InjectEvent(event_type: SyntheticEventType(reply), content: message)
+
   /// Change the gen_statem callback module to `module`.
   /// The new module receives the internal `#gleam_statem` record as its data,
   /// use only for Erlang interop with modules that understand eparch's internals.
@@ -187,6 +200,19 @@ pub type Action(message, reply) {
 pub type TimeoutType {
   StateTimeoutType
   GenericTimeoutType(name: String)
+}
+
+/// The event type used when injecting synthetic events with `inject_event`.
+///
+pub type SyntheticEventType(reply) {
+  /// Delivered as an internal event (same as `NextEvent`)
+  InternalEvent
+  /// Delivered as a cast event
+  CastEvent
+  /// Delivered as an info event
+  InfoEvent
+  /// Delivered as a call event from the given caller
+  CallEvent(from: From(reply))
 }
 
 /// Opaque reference to a caller (for replying to calls).
@@ -590,6 +616,33 @@ pub fn generic_timeout(
   milliseconds: Int,
 ) -> Action(message, reply) {
   GenericTimeout(name:, milliseconds:)
+}
+
+/// Hibernate the process after this callback returns.
+///
+pub fn hibernate() -> Action(message, reply) {
+  Hibernate
+}
+
+/// Conditionally postpone the current event.
+///
+/// `postpone_if(True)` is equivalent to `Postpone`.
+/// `postpone_if(False)` explicitly opts out of postponement.
+///
+pub fn postpone_if(value: Bool) -> Action(message, reply) {
+  PostponeIf(value: value)
+}
+
+/// Inject a synthetic event with an explicit event type.
+///
+/// Unlike `next_event` (always internal), this lets you inject cast,
+/// info, or call events into the event queue.
+///
+pub fn inject_event(
+  event_type: SyntheticEventType(reply),
+  content: message,
+) -> Action(message, reply) {
+  InjectEvent(event_type: event_type, content: content)
 }
 
 /// Create a ChangeCallbackModule action.

--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -628,13 +628,8 @@ pub fn hibernate() -> Action(message, reply) {
   Hibernate
 }
 
-/// Conditionally postpone the current event.
-///
-/// `postpone_if(True)` is equivalent to `Postpone`.
-/// `postpone_if(False)` explicitly opts out of postponement.
-///
-pub fn postpone_if(value: Bool) -> Action(message, reply) {
-  PostponeIf(value: value)
+pub fn postpone() -> Action(message, reply) {
+  Postpone
 }
 
 /// Inject a synthetic event with an explicit event type.

--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -188,12 +188,6 @@ pub type Action(message, reply) {
   /// Hibernate the process after this callback returns.
   Hibernate
 
-  /// Conditionally postpone the current event.
-  /// `PostponeIf(True)` is equivalent to `Postpone`.
-  /// `PostponeIf(False)` explicitly opts out of postponement.
-  /// Postpone this event until after a state change.
-  Postpone
-
   /// Cancel the running state timeout before it fires.
   /// Since OTP 22.1.
   CancelStateTimeout
@@ -664,10 +658,6 @@ pub fn postpone() -> Action(message, reply) {
 ///
 pub fn hibernate() -> Action(message, reply) {
   Hibernate
-}
-
-pub fn postpone() -> Action(message, reply) {
-  Postpone
 }
 
 /// Create a NextEvent action.

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -499,8 +499,6 @@ convert_action_to_erlang(Action) ->
             %% Reply to a gen_statem:call caller.
             %% From is the external type, the raw gen_statem:from() term.
             {reply, From, Response};
-        postpone ->
-            postpone;
         hibernate ->
             hibernate;
         postpone ->

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -477,6 +477,20 @@ convert_action_to_erlang(Action) ->
             {reply, From, Response};
         postpone ->
             postpone;
+        hibernate ->
+            hibernate;
+        {postpone_if, true} ->
+            postpone;
+        {postpone_if, false} ->
+            {postpone, false};
+        {inject_event, internal_event, Content} ->
+            {next_event, internal, Content};
+        {inject_event, cast_event, Content} ->
+            {next_event, cast, Content};
+        {inject_event, info_event, Content} ->
+            {next_event, info, Content};
+        {inject_event, {call_event, From}, Content} ->
+            {next_event, {call, From}, Content};
         {next_event, Content} ->
             {next_event, internal, Content};
         {state_timeout, Milliseconds} ->

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -483,16 +483,14 @@ convert_action_to_erlang(Action) ->
             postpone;
         {postpone_if, false} ->
             {postpone, false};
-        {inject_event, internal_event, Content} ->
+        {next_event, internal_event, Content} ->
             {next_event, internal, Content};
-        {inject_event, cast_event, Content} ->
+        {next_event, cast_event, Content} ->
             {next_event, cast, Content};
-        {inject_event, info_event, Content} ->
+        {next_event, info_event, Content} ->
             {next_event, info, Content};
-        {inject_event, {call_event, From}, Content} ->
+        {next_event, {call_event, From}, Content} ->
             {next_event, {call, From}, Content};
-        {next_event, Content} ->
-            {next_event, internal, Content};
         {state_timeout, Milliseconds} ->
             {state_timeout, Milliseconds, timeout};
         {generic_timeout, Name, Milliseconds} ->

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -479,10 +479,8 @@ convert_action_to_erlang(Action) ->
             postpone;
         hibernate ->
             hibernate;
-        {postpone_if, true} ->
+        postpone ->
             postpone;
-        {postpone_if, false} ->
-            {postpone, false};
         {next_event, internal_event, Content} ->
             {next_event, internal, Content};
         {next_event, cast_event, Content} ->

--- a/test/actions_test.gleam
+++ b/test/actions_test.gleam
@@ -123,7 +123,7 @@ fn next_event_handler(
   case event {
     state_machine.Info(Trigger(reply_with: reply_sub)) ->
       state_machine.keep_state(data, [
-        state_machine.NextEvent(Derived(reply_sub)),
+        state_machine.NextEvent(state_machine.CastEvent, Derived(reply_sub)),
       ])
 
     state_machine.Cast(Derived(reply_with: reply_sub)) -> {
@@ -799,6 +799,29 @@ pub fn request_ids_add_manually_adds_to_collection_test() {
     )
   value |> should.equal(7)
   label |> should.equal("manual")
+}
+
+// STOP AND REPLY
+type SarState {
+  SarRunning
+}
+
+type SarMsg {
+  SarGetAndStop
+}
+
+fn stop_and_reply_handler(
+  event: state_machine.Event(SarState, SarMsg, String),
+  _state: SarState,
+  _data: Nil,
+) -> state_machine.Step(SarState, Nil, SarMsg, String) {
+  case event {
+    state_machine.Call(from, SarGetAndStop) ->
+      state_machine.stop_and_reply(process.Normal, [
+        state_machine.Reply(from, "bye"),
+      ])
+    _ -> state_machine.keep_state(Nil, [])
+  }
 }
 
 pub fn stop_and_reply_sends_reply_before_stopping_test() {

--- a/test/actions_test.gleam
+++ b/test/actions_test.gleam
@@ -639,6 +639,170 @@ pub fn request_ids_add_manually_adds_to_collection_test() {
   label |> should.equal("manual")
 }
 
+// HIBERNATE
+type HibState {
+  HibActive
+}
+
+type HibMsg {
+  HibTrigger
+  HibPing(reply_with: process.Subject(String))
+}
+
+fn hibernate_handler(
+  event: state_machine.Event(HibState, HibMsg, Nil),
+  _state: HibState,
+  data: Nil,
+) -> state_machine.Step(HibState, Nil, HibMsg, Nil) {
+  case event {
+    state_machine.Info(HibTrigger) ->
+      state_machine.keep_state(data, [state_machine.hibernate()])
+
+    state_machine.Info(HibPing(reply_with: sub)) -> {
+      process.send(sub, "pong")
+      state_machine.keep_state(data, [])
+    }
+
+    _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn hibernate_action_does_not_crash_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: HibActive, initial_data: Nil)
+    |> state_machine.on_event(hibernate_handler)
+    |> state_machine.start
+
+  process.send(machine.data, HibTrigger)
+
+  let reply_sub = process.new_subject()
+  process.send(machine.data, HibPing(reply_with: reply_sub))
+  let assert Ok(r) = process.receive(reply_sub, 1000)
+  r |> should.equal("pong")
+}
+
+// POSTPONE IF
+type PifState {
+  PifWaiting
+  PifReady
+}
+
+type PifMsg {
+  PifGo
+  PifAction(reply_with: process.Subject(String))
+}
+
+fn postpone_if_handler(
+  event: state_machine.Event(PifState, PifMsg, Nil),
+  state: PifState,
+  data: Nil,
+) -> state_machine.Step(PifState, Nil, PifMsg, Nil) {
+  case event, state {
+    state_machine.Info(PifAction(_)), PifWaiting ->
+      state_machine.keep_state(data, [state_machine.postpone_if(True)])
+
+    state_machine.Info(PifGo), PifWaiting ->
+      state_machine.next_state(PifReady, data, [])
+
+    state_machine.Info(PifAction(reply_with: sub)), PifReady -> {
+      process.send(sub, "handled")
+      state_machine.keep_state(data, [])
+    }
+
+    _, _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn postpone_if_true_redelivers_event_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: PifWaiting, initial_data: Nil)
+    |> state_machine.on_event(postpone_if_handler)
+    |> state_machine.start
+
+  let reply_sub = process.new_subject()
+  process.send(machine.data, PifAction(reply_with: reply_sub))
+  process.send(machine.data, PifGo)
+
+  let assert Ok(r) = process.receive(reply_sub, 1000)
+  r |> should.equal("handled")
+}
+
+// INJECT EVENT
+type InjState {
+  InjActive
+}
+
+type InjMsg {
+  InjTrigger(reply_with: process.Subject(String))
+  InjDerived(reply_with: process.Subject(String))
+}
+
+fn inject_cast_handler(
+  event: state_machine.Event(InjState, InjMsg, Nil),
+  _state: InjState,
+  data: Nil,
+) -> state_machine.Step(InjState, Nil, InjMsg, Nil) {
+  case event {
+    state_machine.Info(InjTrigger(reply_with: sub)) ->
+      state_machine.keep_state(data, [
+        state_machine.inject_event(state_machine.CastEvent, InjDerived(sub)),
+      ])
+
+    state_machine.Cast(InjDerived(reply_with: sub)) -> {
+      process.send(sub, "cast")
+      state_machine.keep_state(data, [])
+    }
+
+    _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn inject_event_cast_arrives_as_cast_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: InjActive, initial_data: Nil)
+    |> state_machine.on_event(inject_cast_handler)
+    |> state_machine.start
+
+  let reply_sub = process.new_subject()
+  process.send(machine.data, InjTrigger(reply_with: reply_sub))
+
+  let assert Ok(r) = process.receive(reply_sub, 1000)
+  r |> should.equal("cast")
+}
+
+fn inject_info_handler(
+  event: state_machine.Event(InjState, InjMsg, Nil),
+  _state: InjState,
+  data: Nil,
+) -> state_machine.Step(InjState, Nil, InjMsg, Nil) {
+  case event {
+    state_machine.Info(InjTrigger(reply_with: sub)) ->
+      state_machine.keep_state(data, [
+        state_machine.inject_event(state_machine.InfoEvent, InjDerived(sub)),
+      ])
+
+    state_machine.Info(InjDerived(reply_with: sub)) -> {
+      process.send(sub, "info")
+      state_machine.keep_state(data, [])
+    }
+
+    _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn inject_event_info_arrives_as_info_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: InjActive, initial_data: Nil)
+    |> state_machine.on_event(inject_info_handler)
+    |> state_machine.start
+
+  let reply_sub = process.new_subject()
+  process.send(machine.data, InjTrigger(reply_with: reply_sub))
+
+  let assert Ok(r) = process.receive(reply_sub, 1000)
+  r |> should.equal("info")
+}
+
 // ON FORMAT STATUS
 type FmtState {
   FmtIdle


### PR DESCRIPTION
## Description

Expands `Action` support to cover the remaining `gen_statem` action types.

**`Hibernate`**:  hibernates the process after the callback returns, freeing heap memory until the next message arrives. Maps to the OTP `hibernate` action atom.

**`Postpone`**:  conditionally postpones the current event.

Refactor `EventType` is to represent the four different event types.

## Related Issue

- Closes #30

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `gleam format` run
