### PR TITLE
feat: adding support for all gen_statem step returns

### DIFF
--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -142,11 +142,25 @@ pub type Step(state, data, message, reply) {
   /// Transition to a new state
   NextState(state: state, data: data, actions: List(Action(message, reply)))
 
-  /// Keep the current state
+  /// Keep the current state, updating data
   KeepState(data: data, actions: List(Action(message, reply)))
+
+  /// Keep the current state without re-specifying data (OTP optimization).
+  KeepStateAndData(actions: List(Action(message, reply)))
+
+  /// Re-enter the current state with new data, re-triggering the state_enter
+  /// callback if enabled.
+  RepeatState(data: data, actions: List(Action(message, reply)))
+
+  /// Re-enter the current state without changing data.
+  RepeatStateAndData(actions: List(Action(message, reply)))
 
   /// Stop the state machine
   Stop(reason: ExitReason)
+
+  /// Stop the state machine and atomically send replies to pending callers.
+  /// Only `Reply(from, response)` actions are valid in the replies list.
+  StopAndReply(reason: ExitReason, replies: List(Action(message, reply)))
 }
 
 /// Actions (side effects) to perform after handling an event.
@@ -530,6 +544,35 @@ pub fn keep_state(
   KeepState(data:, actions:)
 }
 
+/// Keep the current state without re-specifying data.
+///
+/// Use instead of `keep_state` when data has not changed, to avoid
+/// an unnecessary copy in the `#gleam_statem` record.
+///
+pub fn keep_state_and_data(
+  actions: List(Action(message, reply)),
+) -> Step(state, data, message, reply) {
+  KeepStateAndData(actions: actions)
+}
+
+/// Re-enter the current state with new data, re-triggering the state_enter
+/// callback if enabled.
+///
+pub fn repeat_state(
+  data: data,
+  actions: List(Action(message, reply)),
+) -> Step(state, data, message, reply) {
+  RepeatState(data: data, actions: actions)
+}
+
+/// Re-enter the current state without changing data.
+///
+pub fn repeat_state_and_data(
+  actions: List(Action(message, reply)),
+) -> Step(state, data, message, reply) {
+  RepeatStateAndData(actions: actions)
+}
+
 /// Create a Stop step indicating the state machine should terminate.
 ///
 /// ## Example
@@ -540,6 +583,17 @@ pub fn keep_state(
 ///
 pub fn stop(reason: ExitReason) -> Step(state, data, message, reply) {
   Stop(reason:)
+}
+
+/// Stop the state machine and atomically send replies to pending callers.
+///
+/// Only `Reply(from, response)` actions are valid in the `replies` list.
+///
+pub fn stop_and_reply(
+  reason: ExitReason,
+  replies: List(Action(message, reply)),
+) -> Step(state, data, message, reply) {
+  StopAndReply(reason: reason, replies: replies)
 }
 
 /// Create a Reply action.

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -462,8 +462,32 @@ convert_step_to_erlang(GleamStep, GleamStatem) ->
                 [] -> {keep_state, NewGleamStatem};
                 _ -> {keep_state, NewGleamStatem, Actions}
             end;
+        {keep_state_and_data, GleamActions} ->
+            Actions = convert_actions_to_erlang(GleamActions),
+            case Actions of
+                [] -> keep_state_and_data;
+                _ -> {keep_state_and_data, Actions}
+            end;
+        {repeat_state, NewData, GleamActions} ->
+            Actions = convert_actions_to_erlang(GleamActions),
+            NewGleamStatem = GleamStatem#gleam_statem{
+                gleam_data = NewData
+            },
+            case Actions of
+                [] -> {repeat_state, NewGleamStatem};
+                _ -> {repeat_state, NewGleamStatem, Actions}
+            end;
+        {repeat_state_and_data, GleamActions} ->
+            Actions = convert_actions_to_erlang(GleamActions),
+            case Actions of
+                [] -> repeat_state_and_data;
+                _ -> {repeat_state_and_data, Actions}
+            end;
         {stop, Reason} ->
-            {stop, convert_exit_reason(Reason)}
+            {stop, convert_exit_reason(Reason)};
+        {stop_and_reply, Reason, GleamActions} ->
+            Replies = convert_actions_to_erlang(GleamActions),
+            {stop_and_reply, convert_exit_reason(Reason), Replies}
     end.
 
 convert_actions_to_erlang(GleamActions) ->

--- a/test/actions_test.gleam
+++ b/test/actions_test.gleam
@@ -639,6 +639,127 @@ pub fn request_ids_add_manually_adds_to_collection_test() {
   label |> should.equal("manual")
 }
 
+type KsdState {
+  KsdRunning
+}
+
+type KsdMsg {
+  KsdPing(reply_with: process.Subject(String))
+}
+
+fn keep_state_and_data_handler(
+  event: state_machine.Event(KsdState, KsdMsg, Nil),
+  _state: KsdState,
+  _data: Nil,
+) -> state_machine.Step(KsdState, Nil, KsdMsg, Nil) {
+  case event {
+    state_machine.Info(KsdPing(reply_with: sub)) -> {
+      process.send(sub, "pong")
+      state_machine.keep_state_and_data([])
+    }
+    _ -> state_machine.keep_state_and_data([])
+  }
+}
+
+pub fn keep_state_and_data_keeps_machine_running_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: KsdRunning, initial_data: Nil)
+    |> state_machine.on_event(keep_state_and_data_handler)
+    |> state_machine.start
+
+  let sub = process.new_subject()
+  process.send(machine.data, KsdPing(reply_with: sub))
+  let assert Ok(r) = process.receive(sub, 1000)
+  r |> should.equal("pong")
+}
+
+type RsState {
+  RsActive
+}
+
+type RsMsg {
+  RsEnterCount(reply_with: process.Subject(Int))
+  RsTrigger
+}
+
+fn repeat_state_handler(
+  event: state_machine.Event(RsState, RsMsg, Nil),
+  _state: RsState,
+  data: Int,
+) -> state_machine.Step(RsState, Int, RsMsg, Nil) {
+  case event {
+    state_machine.Enter(_) -> state_machine.keep_state(data + 1, [])
+
+    state_machine.Info(RsTrigger) -> state_machine.repeat_state(data, [])
+
+    state_machine.Info(RsEnterCount(reply_with: sub)) -> {
+      process.send(sub, data)
+      state_machine.keep_state(data, [])
+    }
+
+    _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn repeat_state_triggers_state_enter_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: RsActive, initial_data: 0)
+    |> state_machine.with_state_enter()
+    |> state_machine.on_event(repeat_state_handler)
+    |> state_machine.start
+
+  process.send(machine.data, RsTrigger)
+  process.send(machine.data, RsTrigger)
+
+  let sub = process.new_subject()
+  process.send(machine.data, RsEnterCount(reply_with: sub))
+  let assert Ok(count) = process.receive(sub, 1000)
+  // Initial enter + 2 repeat_state calls = 3
+  count |> should.equal(3)
+}
+
+type SarState {
+  SarRunning
+}
+
+type SarMsg {
+  SarGetAndStop
+}
+
+fn stop_and_reply_handler(
+  event: state_machine.Event(SarState, SarMsg, String),
+  _state: SarState,
+  data: Nil,
+) -> state_machine.Step(SarState, Nil, SarMsg, String) {
+  case event {
+    state_machine.Call(from, SarGetAndStop) ->
+      state_machine.stop_and_reply(process.Normal, [
+        state_machine.Reply(from, "bye"),
+      ])
+    _ -> state_machine.keep_state(data, [])
+  }
+}
+
+pub fn stop_and_reply_sends_reply_before_stopping_test() {
+  let assert Ok(machine) =
+    state_machine.new(initial_state: SarRunning, initial_data: Nil)
+    |> state_machine.on_event(stop_and_reply_handler)
+    |> state_machine.start
+
+  let monitor = process.monitor(machine.pid)
+  let sel =
+    process.new_selector()
+    |> process.select_specific_monitor(monitor, fn(d) { d })
+
+  let req: state_machine.RequestId(String) =
+    state_machine.send_request(machine.data, SarGetAndStop)
+  let assert Ok(reply) = state_machine.receive_response(req, 1000)
+  reply |> should.equal("bye")
+
+  let assert Ok(down) = process.selector_receive(sel, 1000)
+  down.reason |> should.equal(process.Normal)
+}
+
 // ON FORMAT STATUS
 type FmtState {
   FmtIdle


### PR DESCRIPTION
## Description

Adds the four missing `gen_statem` step/return-value variants to eparch's `Step` type.

**`KeepStateAndData(actions)`**: maps to OTP's `keep_state_and_data`. Like `KeepState` but does not re-specify the data field, signalling to the runtime that data is unchanged and avoiding an unnecessary record copy.

**`RepeatState(data, actions)`**: re-enters the current state with new data, re-triggering the `state_enter` callback if enabled. Useful for resetting entry-point side effects (e.g. restarting a state timeout) without changing the logical state.

**`RepeatStateAndData(actions)`**: same as `RepeatState` but keeps data unchanged. Maps to OTP's `repeat_state_and_data`.

**`StopAndReply(reason, replies)`**: atomically stops the state machine and sends replies to pending callers in the same OTP step. Prevents callers from blocking if the server shuts down mid-request. Only `Reply(from, response)` actions are valid in the replies list.

## Related Issue

- Closes #29

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated (if applicable)
- [x] `gleam format` run