### PR TITLE
feat: adding async request/response

### DIFF
--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -282,10 +282,10 @@ pub fn on_format_status(
 /// ```
 ///
 pub fn with_call_handler(
-  handler: Handler(state, event),
+  handler: Handler(state, event, _, _),
   on_call: fn(request, state) -> #(reply, state),
-) -> Handler(state, event) {
-  Handler(..handler, on_call: Some(coerce(on_call)))
+) -> Handler(state, event, request, reply) {
+  Handler(..handler, on_call: Some(on_call))
 }
 
 @external(erlang, "gleam_stdlib", "identity")

--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -214,6 +214,17 @@ pub fn new_handler(
     on_terminate: None,
     on_format_status: None,
   )
+pub fn new_handler(
+  initial_state: state,
+  handler: fn(event, state) -> EventStep(state),
+) -> Handler(state, event, Nil, Nil) {
+  Handler(
+    init_state: initial_state,
+    on_event: handler,
+    on_call: None,
+    on_terminate: None,
+    on_format_status: None,
+  )
 }
 
 /// Attach a cleanup function called when the handler is removed or the manager

--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -126,20 +126,20 @@ pub type MonitoredManager(event) {
 }
 
 /// Errors that can occur when adding a handler.
-pub type AddError {
+pub type AddError(request, reply) {
   /// A handler with the same identity is already registered. The field
   /// carries the `HandlerRef` that caused the collision.
-  HandlerAlreadyExists(handler_ref: HandlerRef)
+  HandlerAlreadyExists(handler_ref: HandlerRef(request, reply))
   /// The handler's initialisation failed. `reason` is a human-readable
   /// string produced from the raw Erlang error term.
   InitFailed(reason: String)
 }
 
 /// Errors that can occur when removing a handler.
-pub type RemoveError {
+pub type RemoveError(request, reply) {
   /// No handler with the given ref is currently registered. The field
   /// carries the `HandlerRef` the caller supplied.
-  HandlerNotFound(handler_ref: HandlerRef)
+  HandlerNotFound(handler_ref: HandlerRef(request, reply))
   /// Removal failed for another reason.
   RemoveFailed(reason: String)
 }
@@ -165,7 +165,11 @@ pub opaque type Handler(state, event, request, reply) {
 /// `add_supervised_handler`. Pass them to `remove_handler` to unregister a
 /// specific handler, or compare them with values returned by `which_handlers`.
 ///
-pub type HandlerRef
+/// The phantom `request`/`reply` parameters track the call protocol of the
+/// handler, so `send_request` cannot be called with a mismatched request type.
+/// Handlers without a call protocol carry `Nil`/`Nil`.
+///
+pub type HandlerRef(request, reply)
 
 /// An opaque reference to a running event manager process.
 ///
@@ -439,16 +443,16 @@ fn do_manager_pid(manager: Manager(event)) -> Pid
 ///
 pub fn add_handler(
   manager: Manager(event),
-  handler: Handler(state, event),
-) -> Result(HandlerRef, AddError) {
+  handler: Handler(state, event, request, reply),
+) -> Result(HandlerRef(request, reply), AddError(request, reply)) {
   do_add_handler(manager, handler)
 }
 
 @external(erlang, "event_manager_ffi", "do_add_handler")
 fn do_add_handler(
   manager: Manager(event),
-  handler: Handler(state, event),
-) -> Result(HandlerRef, AddError)
+  handler: Handler(state, event, request, reply),
+) -> Result(HandlerRef(request, reply), AddError(request, reply))
 
 /// Register a supervised handler with the event manager.
 ///
@@ -466,16 +470,16 @@ fn do_add_handler(
 ///
 pub fn add_supervised_handler(
   manager: Manager(event),
-  handler: Handler(state, event),
-) -> Result(HandlerRef, AddError) {
+  handler: Handler(state, event, request, reply),
+) -> Result(HandlerRef(request, reply), AddError(request, reply)) {
   do_add_supervised_handler(manager, handler)
 }
 
 @external(erlang, "event_manager_ffi", "do_add_sup_handler")
 fn do_add_supervised_handler(
   manager: Manager(event),
-  handler: Handler(state, event),
-) -> Result(HandlerRef, AddError)
+  handler: Handler(state, event, request, reply),
+) -> Result(HandlerRef(request, reply), AddError(request, reply))
 
 /// Remove a specific handler from the event manager.
 ///
@@ -483,25 +487,29 @@ fn do_add_supervised_handler(
 ///
 pub fn remove_handler(
   manager: Manager(event),
-  handler_ref: HandlerRef,
-) -> Result(Nil, RemoveError) {
+  handler_ref: HandlerRef(request, reply),
+) -> Result(Nil, RemoveError(request, reply)) {
   do_remove_handler(manager, handler_ref)
 }
 
 @external(erlang, "event_manager_ffi", "do_remove_handler")
 fn do_remove_handler(
   manager: Manager(event),
-  handler_ref: HandlerRef,
-) -> Result(Nil, RemoveError)
+  handler_ref: HandlerRef(request, reply),
+) -> Result(Nil, RemoveError(request, reply))
 
 /// Return the list of `HandlerRef`s for all currently registered handlers.
 ///
-pub fn which_handlers(manager: Manager(event)) -> List(HandlerRef) {
+pub fn which_handlers(
+  manager: Manager(event),
+) -> List(HandlerRef(request, reply)) {
   do_which_handlers(manager)
 }
 
 @external(erlang, "event_manager_ffi", "do_which_handlers")
-fn do_which_handlers(manager: Manager(event)) -> List(HandlerRef)
+fn do_which_handlers(
+  manager: Manager(event),
+) -> List(HandlerRef(request, reply))
 
 // ---------------------------------------------------------------------------
 // Notifications

--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -596,7 +596,7 @@ pub type CheckResponse(reply) {
 @external(erlang, "event_manager_ffi", "send_request")
 pub fn send_request(
   manager: Manager(event),
-  handler_ref: HandlerRef,
+  handler_ref: HandlerRef(request, reply),
   request: request,
 ) -> RequestId(reply)
 

--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -157,6 +157,14 @@ pub opaque type Handler(state, event) {
     on_terminate: Option(fn(state) -> Nil),
     on_format_status: Option(fn(state) -> String),
   )
+pub opaque type Handler(state, event, request, reply) {
+  Handler(
+    init_state: state,
+    on_event: fn(event, state) -> EventStep(state),
+    on_call: Option(fn(request, state) -> #(reply, state)),
+    on_terminate: Option(fn(state) -> Nil),
+    on_format_status: Option(fn(state) -> String),
+  )
 }
 
 /// An opaque reference to a specific registered handler instance.

--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -37,6 +37,7 @@
 //// }
 //// ```
 
+import gleam/dynamic.{type Dynamic}
 import gleam/erlang/process.{type Monitor, type Name, type Pid}
 import gleam/option.{type Option, None, Some}
 
@@ -152,6 +153,7 @@ pub opaque type Handler(state, event) {
   Handler(
     init_state: state,
     on_event: fn(event, state) -> EventStep(state),
+    on_call: Option(Dynamic),
     on_terminate: Option(fn(state) -> Nil),
     on_format_status: Option(fn(state) -> String),
   )
@@ -200,6 +202,7 @@ pub fn new_handler(
   Handler(
     init_state: initial_state,
     on_event: handler,
+    on_call: None,
     on_terminate: None,
     on_format_status: None,
   )
@@ -244,6 +247,30 @@ pub fn on_format_status(
 ) -> Handler(state, event) {
   Handler(..handler, on_format_status: Some(formatter))
 }
+
+/// Attach a call handler to a handler, enabling async request/response via
+/// `send_request`. The `on_call` function receives the request and the current
+/// handler state, and must return a `#(reply, new_state)` tuple.
+///
+/// Without this, `send_request` calls to this handler will fail with
+/// `Error(RequestCrashed(_))`.
+///
+/// ## Example
+///
+/// ```gleam
+/// event_manager.new_handler(0, on_event)
+/// |> event_manager.with_call_handler(fn(GetCount, count) { #(count, count) })
+/// ```
+///
+pub fn with_call_handler(
+  handler: Handler(state, event),
+  on_call: fn(request, state) -> #(reply, state),
+) -> Handler(state, event) {
+  Handler(..handler, on_call: Some(coerce(on_call)))
+}
+
+@external(erlang, "gleam_stdlib", "identity")
+fn coerce(a: a) -> b
 
 // ---------------------------------------------------------------------------
 // StartOptions builder
@@ -507,3 +534,104 @@ pub fn sync_notify(manager: Manager(event), event: event) -> Nil {
 
 @external(erlang, "event_manager_ffi", "do_sync_notify")
 fn do_sync_notify(manager: Manager(event), event: event) -> Nil
+
+// ---------------------------------------------------------------------------
+// Async call API (OTP 23+)
+// ---------------------------------------------------------------------------
+
+/// An opaque handle for a pending async call issued by `send_request`.
+///
+/// The phantom type `reply` tracks the expected response type at compile time.
+///
+pub type RequestId(reply)
+
+/// Errors that `receive_response` and `wait_response` can return.
+///
+pub type ReceiveError {
+  /// No reply arrived within the timeout.
+  ReceiveTimeout
+  /// The manager (or handler) exited before replying. The `reason` field
+  /// carries a human-readable description of the exit reason.
+  RequestCrashed(reason: String)
+}
+
+/// The result of a non-blocking `check_response` call.
+///
+pub type CheckResponse(reply) {
+  /// A reply for the given `RequestId` was found in the mailbox.
+  CheckGotReply(reply: reply)
+  /// The message was not a reply for this `RequestId`.
+  CheckNoReply
+  /// The manager (or handler) exited before replying.
+  CheckCrashed(reason: String)
+}
+
+/// Asynchronously call a specific handler and return a `RequestId`.
+///
+/// Unlike `sync_notify`, this targets one handler by its `HandlerRef` and
+/// expects a reply. The handler must have been registered with
+/// `with_call_handler` set; otherwise `receive_response` will return
+/// `Error(RequestCrashed(_))`.
+///
+/// Use `receive_response` or `wait_response` to collect the reply later, or
+/// `check_response` to poll non-blockingly.
+///
+/// ## Example
+///
+/// ```gleam
+/// let req: event_manager.RequestId(Int) =
+///   event_manager.send_request(mgr, handler_ref, GetCount)
+/// // ... do other work ...
+/// let assert Ok(count) = event_manager.receive_response(req, 1000)
+/// ```
+///
+@external(erlang, "event_manager_ffi", "send_request")
+pub fn send_request(
+  manager: Manager(event),
+  handler_ref: HandlerRef,
+  request: request,
+) -> RequestId(reply)
+
+/// Wait up to `timeout` milliseconds for the reply to a `RequestId`.
+///
+/// Returns `Ok(reply)` on success, `Error(ReceiveTimeout)` if no reply
+/// arrives in time, or `Error(RequestCrashed(reason))` if the manager exited.
+///
+@external(erlang, "event_manager_ffi", "receive_response")
+pub fn receive_response(
+  request_id: RequestId(reply),
+  timeout: Int,
+) -> Result(reply, ReceiveError)
+
+/// Same as `receive_response`. Provided for API parity with OTP's
+/// `gen_server:wait_response/2`.
+///
+pub fn wait_response(
+  request_id: RequestId(reply),
+  timeout: Int,
+) -> Result(reply, ReceiveError) {
+  receive_response(request_id, timeout)
+}
+
+/// Non-blocking check: inspect `message` to see if it is a reply for
+/// `request_id`.
+///
+/// Useful inside a custom `process.Selector` receive loop. Pass any message
+/// you receive; if it does not belong to this request `CheckNoReply` is
+/// returned and the message is left for other handlers.
+///
+/// ## Example
+///
+/// ```gleam
+/// case event_manager.check_response(raw_msg, req) {
+///   event_manager.CheckGotReply(value) -> // handle value
+///   event_manager.CheckNoReply -> // not ours, pass it on
+///   event_manager.CheckCrashed(reason) -> // handle error
+/// }
+/// ```
+///
+@external(erlang, "event_manager_ffi", "check_response")
+pub fn check_response(
+  message: Dynamic,
+  request_id: RequestId(reply),
+) -> CheckResponse(reply)

--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -196,17 +196,6 @@ pub type Manager(event)
 /// ```
 ///
 pub fn new_handler(
-  initial_state initial_state: state,
-  on_event handler: fn(event, state) -> EventStep(state),
-) -> Handler(state, event) {
-  Handler(
-    init_state: initial_state,
-    on_event: handler,
-    on_call: None,
-    on_terminate: None,
-    on_format_status: None,
-  )
-pub fn new_handler(
   initial_state: state,
   handler: fn(event, state) -> EventStep(state),
 ) -> Handler(state, event, Nil, Nil) {
@@ -230,9 +219,9 @@ pub fn new_handler(
 /// ```
 ///
 pub fn on_terminate(
-  handler: Handler(state, event),
+  handler: Handler(state, event, _, _),
   cleanup: fn(state) -> Nil,
-) -> Handler(state, event) {
+) -> Handler(state, event, _, _) {
   Handler(..handler, on_terminate: Some(cleanup))
 }
 
@@ -253,9 +242,9 @@ pub fn on_terminate(
 /// ```
 ///
 pub fn on_format_status(
-  handler: Handler(state, event),
+  handler: Handler(state, event, _, _),
   formatter: fn(state) -> String,
-) -> Handler(state, event) {
+) -> Handler(state, event, _, _) {
   Handler(..handler, on_format_status: Some(formatter))
 }
 
@@ -279,9 +268,6 @@ pub fn with_call_handler(
 ) -> Handler(state, event, request, reply) {
   Handler(..handler, on_call: Some(on_call))
 }
-
-@external(erlang, "gleam_stdlib", "identity")
-fn coerce(a: a) -> b
 
 // ---------------------------------------------------------------------------
 // StartOptions builder

--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -149,14 +149,6 @@ pub type RemoveError {
 /// Create one with `new_handler/2` and optionally extend it with
 /// `on_terminate/2` and `on_format_status/2`.
 ///
-pub opaque type Handler(state, event) {
-  Handler(
-    init_state: state,
-    on_event: fn(event, state) -> EventStep(state),
-    on_call: Option(Dynamic),
-    on_terminate: Option(fn(state) -> Nil),
-    on_format_status: Option(fn(state) -> String),
-  )
 pub opaque type Handler(state, event, request, reply) {
   Handler(
     init_state: state,

--- a/src/event_manager_ffi.erl
+++ b/src/event_manager_ffi.erl
@@ -28,7 +28,10 @@ every installed instance distinguishable.
     do_remove_handler/2,
     do_which_handlers/1,
     do_notify/2,
-    do_sync_notify/2
+    do_sync_notify/2,
+    send_request/3,
+    receive_response/2,
+    check_response/2
 ]).
 
 %% gen_event handler callbacks
@@ -52,6 +55,8 @@ every installed instance distinguishable.
     gleam_state,
     % fn(event, state) -> EventStep
     on_event,
+    % none | {some, fn(request, state) -> {reply, new_state}}
+    on_call,
     % none | {some, fn(state) -> nil}
     on_terminate,
     % none | {some, fn(state) -> binary()}
@@ -275,11 +280,12 @@ level as a 5-tuple:
 We unpack it here and store the fields alongside the unique Ref in a
 `#gleam_handler{}` record.
 """.
-init({{handler, InitState, OnEvent, OnTerminate, OnFormatStatus}, Ref}) ->
+init({{handler, InitState, OnEvent, OnCall, OnTerminate, OnFormatStatus}, Ref}) ->
     State = #gleam_handler{
         ref = Ref,
         gleam_state = InitState,
         on_event = OnEvent,
+        on_call = OnCall,
         on_terminate = OnTerminate,
         on_format_status = OnFormatStatus
     },
@@ -317,11 +323,19 @@ handle_info(Info, #gleam_handler{on_event = OnEvent, gleam_state = GleamState} =
 -doc """
 Synchronous call to a specific handler via `gen_event:call/3,4`.
 
-Not exposed in the Gleam API (users embed `Subject(reply)` in their event type
-instead), but must be implemented to satisfy the gen_event behaviour.
+When the handler was registered with `with_call_handler`, the `on_call`
+function is invoked with the request and the current Gleam state; the returned
+`{Reply, NewState}` tuple is used to update the handler and reply to the
+caller. Handlers without `on_call` return `{error, not_supported}`.
 """.
-handle_call(_Request, State) ->
-    {ok, {error, not_supported}, State}.
+handle_call(Request, #gleam_handler{on_call = OnCall, gleam_state = GleamState} = State) ->
+    case OnCall of
+        none ->
+            {ok, {gleam_call_error, not_supported}, State};
+        {some, F} ->
+            {Reply, NewGleamState} = F(Request, GleamState),
+            {ok, {gleam_call_ok, Reply}, State#gleam_handler{gleam_state = NewGleamState}}
+    end.
 
 -doc """
 Handler teardown.
@@ -366,4 +380,70 @@ format_status(
             Status;
         {some, Fun} ->
             Status#{state => Fun(GleamState)}
+    end.
+
+%%%===================================================================
+%%% Async call API — OTP 23+ style
+%%%===================================================================
+
+-doc """
+Asynchronously call a specific handler and return a request reference.
+
+Spawns a lightweight helper process that calls `gen_event:call/4` (with a
+5-second hard timeout) and sends the result back to the caller tagged with a
+unique reference. Use `receive_response/2` or `check_response/2` to collect
+the reply.
+""".
+send_request(Manager, HandlerId, Request) ->
+    ReqRef = make_ref(),
+    Caller = self(),
+    spawn(fun() ->
+        Mon = erlang:monitor(process, Manager),
+        try
+            case gen_event:call(Manager, HandlerId, Request, 5000) of
+                {gleam_call_ok, Reply} ->
+                    erlang:demonitor(Mon, [flush]),
+                    Caller ! {gleam_event_call_reply, ReqRef, {ok, Reply}};
+                {gleam_call_error, Reason} ->
+                    erlang:demonitor(Mon, [flush]),
+                    Caller ! {gleam_event_call_reply, ReqRef, {error, Reason}}
+            end
+        catch
+            exit:ExitReason ->
+                erlang:demonitor(Mon, [flush]),
+                Caller ! {gleam_event_call_reply, ReqRef, {error, ExitReason}}
+        end
+    end),
+    ReqRef.
+
+-doc """
+Block up to `Timeout` milliseconds for the reply to `ReqRef`.
+
+Returns `{ok, Reply}` on success, `{error, receive_timeout}` on timeout, or
+`{error, {request_crashed, Reason}}` if the manager exited before replying.
+""".
+receive_response(ReqRef, Timeout) ->
+    receive
+        {gleam_event_call_reply, ReqRef, {ok, Reply}} ->
+            {ok, Reply};
+        {gleam_event_call_reply, ReqRef, {error, Reason}} ->
+            {error, {request_crashed, format_reason(Reason)}}
+    after Timeout ->
+        {error, receive_timeout}
+    end.
+
+-doc """
+Non-blocking check: test whether `Msg` is a reply for `ReqRef`.
+
+Returns `{check_got_reply, Reply}`, `{check_crashed, Reason}`, or
+`check_no_reply` if the message belongs to a different request.
+""".
+check_response(Msg, ReqRef) ->
+    case Msg of
+        {gleam_event_call_reply, ReqRef, {ok, Reply}} ->
+            {check_got_reply, Reply};
+        {gleam_event_call_reply, ReqRef, {error, Reason}} ->
+            {check_crashed, format_reason(Reason)};
+        _ ->
+            check_no_reply
     end.

--- a/test/event_manager_test.gleam
+++ b/test/event_manager_test.gleam
@@ -507,24 +507,6 @@ pub fn wait_response_returns_same_reply_as_receive_response_test() {
   event_manager.stop(mgr)
 }
 
-pub fn receive_response_errors_when_handler_has_no_on_call_test() {
-  let assert Ok(mgr) = event_manager.start()
-
-  let handler =
-    event_manager.new_handler(0, fn(_event, state) {
-      event_manager.Continue(state)
-    })
-
-  let assert Ok(ref) = event_manager.add_handler(mgr, handler)
-
-  let req: event_manager.RequestId(Int) =
-    event_manager.send_request(mgr, ref, GetCount)
-  let assert Error(event_manager.RequestCrashed(_)) =
-    event_manager.receive_response(req, 1000)
-
-  event_manager.stop(mgr)
-}
-
 pub fn check_response_returns_check_no_reply_for_unrelated_message_test() {
   let assert Ok(mgr) = event_manager.start()
 

--- a/test/event_manager_test.gleam
+++ b/test/event_manager_test.gleam
@@ -407,5 +407,178 @@ pub fn start_monitor_accepts_option_passthrough_test() {
 
   let assert Ok(monitored) = event_manager.start_monitor(options)
 
+  // Consume the DOWN message produced when the manager stops so it does not
+  // linger in the mailbox and interfere with later tests.
+  let selector =
+    process.new_selector()
+    |> process.select_specific_monitor(monitored.monitor, fn(down) { down })
+
   event_manager.stop(monitored.manager)
+
+  let assert Ok(_down) = process.selector_receive(from: selector, within: 1000)
+}
+
+// ---------------------------------------------------------------------------
+// SEND_REQUEST / ASYNC CALL (OTP 23+)
+//
+// send_request targets a specific handler via its HandlerRef.  The handler
+// must be registered with `with_call_handler`; otherwise receive_response
+// returns Error(RequestCrashed(_)).
+// ---------------------------------------------------------------------------
+
+type CallMsg {
+  GetCount
+  IncrCount
+}
+
+pub fn send_request_returns_reply_test() {
+  let assert Ok(mgr) = event_manager.start()
+
+  let handler =
+    event_manager.new_handler(0, fn(event, count) {
+      case event {
+        IncrCount -> event_manager.Continue(count + 1)
+        _ -> event_manager.Continue(count)
+      }
+    })
+    |> event_manager.with_call_handler(fn(request, count) {
+      case request {
+        GetCount -> #(count, count)
+        _ -> #(count, count)
+      }
+    })
+
+  let assert Ok(ref) = event_manager.add_handler(mgr, handler)
+
+  let req: event_manager.RequestId(Int) =
+    event_manager.send_request(mgr, ref, GetCount)
+  let assert Ok(count) = event_manager.receive_response(req, 1000)
+  count |> should.equal(0)
+
+  event_manager.stop(mgr)
+}
+
+pub fn send_request_sees_latest_handler_state_test() {
+  let assert Ok(mgr) = event_manager.start()
+
+  let handler =
+    event_manager.new_handler(0, fn(event, count) {
+      case event {
+        IncrCount -> event_manager.Continue(count + 1)
+        _ -> event_manager.Continue(count)
+      }
+    })
+    |> event_manager.with_call_handler(fn(request, count) {
+      case request {
+        GetCount -> #(count, count)
+        _ -> #(count, count)
+      }
+    })
+
+  let assert Ok(ref) = event_manager.add_handler(mgr, handler)
+
+  event_manager.sync_notify(mgr, IncrCount)
+  event_manager.sync_notify(mgr, IncrCount)
+
+  let req: event_manager.RequestId(Int) =
+    event_manager.send_request(mgr, ref, GetCount)
+  let assert Ok(count) = event_manager.receive_response(req, 1000)
+  count |> should.equal(2)
+
+  event_manager.stop(mgr)
+}
+
+pub fn wait_response_returns_same_reply_as_receive_response_test() {
+  let assert Ok(mgr) = event_manager.start()
+
+  let handler =
+    event_manager.new_handler(42, fn(_event, state) {
+      event_manager.Continue(state)
+    })
+    |> event_manager.with_call_handler(fn(_request, state) { #(state, state) })
+
+  let assert Ok(ref) = event_manager.add_handler(mgr, handler)
+
+  let req: event_manager.RequestId(Int) =
+    event_manager.send_request(mgr, ref, GetCount)
+  let assert Ok(value) = event_manager.wait_response(req, 1000)
+  value |> should.equal(42)
+
+  event_manager.stop(mgr)
+}
+
+pub fn receive_response_errors_when_handler_has_no_on_call_test() {
+  let assert Ok(mgr) = event_manager.start()
+
+  let handler =
+    event_manager.new_handler(0, fn(_event, state) {
+      event_manager.Continue(state)
+    })
+
+  let assert Ok(ref) = event_manager.add_handler(mgr, handler)
+
+  let req: event_manager.RequestId(Int) =
+    event_manager.send_request(mgr, ref, GetCount)
+  let assert Error(event_manager.RequestCrashed(_)) =
+    event_manager.receive_response(req, 1000)
+
+  event_manager.stop(mgr)
+}
+
+pub fn check_response_returns_check_no_reply_for_unrelated_message_test() {
+  let assert Ok(mgr) = event_manager.start()
+
+  let handler =
+    event_manager.new_handler(0, fn(_event, state) {
+      event_manager.Continue(state)
+    })
+    |> event_manager.with_call_handler(fn(_req, state) { #(state, state) })
+
+  let assert Ok(ref) = event_manager.add_handler(mgr, handler)
+
+  let req: event_manager.RequestId(Int) =
+    event_manager.send_request(mgr, ref, GetCount)
+
+  // An unrelated dynamic value should not match.
+  let unrelated = dynamic.int(42)
+  event_manager.check_response(unrelated, req)
+  |> should.equal(event_manager.CheckNoReply)
+
+  // Drain the real reply so the process stays clean.
+  let _ = event_manager.receive_response(req, 1000)
+
+  event_manager.stop(mgr)
+}
+
+pub fn check_response_returns_check_got_reply_when_message_matches_test() {
+  // Discard any stale messages (e.g. unconsumed DOWN messages from earlier
+  // tests) so that the select_other catch-all below doesn't capture them.
+  process.flush_messages()
+
+  let assert Ok(mgr) = event_manager.start()
+
+  let handler =
+    event_manager.new_handler(7, fn(_event, state) {
+      event_manager.Continue(state)
+    })
+    |> event_manager.with_call_handler(fn(_req, state) { #(state, state) })
+
+  let assert Ok(ref) = event_manager.add_handler(mgr, handler)
+
+  let req: event_manager.RequestId(Int) =
+    event_manager.send_request(mgr, ref, GetCount)
+
+  // Receive the raw reply message from the mailbox via select_other, then
+  // hand it to check_response.
+  let selector =
+    process.new_selector()
+    |> process.select_other(fn(msg) { msg })
+  let assert Ok(raw) = process.selector_receive(from: selector, within: 1000)
+
+  case event_manager.check_response(raw, req) {
+    event_manager.CheckGotReply(value) -> value |> should.equal(7)
+    _ -> should.fail()
+  }
+
+  event_manager.stop(mgr)
 }


### PR DESCRIPTION
## Description

Adds an OTP 23+ style async call API for event manager handlers, flowing through `handle_call/2`.

Previously, `handle_call/2` always returned `{error, not_supported}`, making per-handler request/response impossible. This PR introduces an opt-in `with_call_handler` builder and a set of async call functions that let callers fan out requests to specific handlers and collect replies without blocking.

> send_request(manager, ref, "hi") against a handler expecting Int is now a compile-time type error.

### New API

**Builder**

- `with_call_handler(handler, fn(request, state) -> #(reply, state))` registers a call handler on an existing `Handler`. Handlers without it continue to work unchanged.

**Async call functions**

- `send_request(manager, handler_ref, request) -> RequestId(reply)` sends an async call to a specific handler and returns immediately
- `receive_response(request_id, timeout) -> Result(reply, ReceiveError)` blocks until the reply arrives or times out
- `wait_response(request_id, timeout) -> Result(reply, ReceiveError)` alias for `receive_response`, provided for API parity
- `check_response(message, request_id) -> CheckResponse(reply)` non-blocking check for use inside custom receive loops

**New types**: `RequestId(reply)`, `ReceiveError`, `CheckResponse(reply)`

### Implementation notes

`gen_event` has no native async call API (unlike `gen_server` and `gen_statem`). `send_request` achieves the async behaviour by spawning a lightweight helper process that calls `gen_event:call/4` synchronously and delivers the result back to the caller tagged with a unique reference. The `handle_call/2` callback now uses an internal tagging scheme (`gleam_call_ok` / `gleam_call_error`) to distinguish a successful reply from a "no call handler" error without double-wrapping the result.

## Related Issue

- Closes #23 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated (if applicable)
- [x] `gleam format` run
