### PR TITLE
#31 ADD a better way to do server name registration

### DIFF
--- a/examples/01-push-button/src/pushbutton.gleam
+++ b/examples/01-push-button/src/pushbutton.gleam
@@ -21,10 +21,10 @@ pub type Msg {
 
 // API
 /// Start the pushbutton with press count at 0 and initial state Off.
-pub fn start() -> Result(sm.Started(process.Subject(Msg)), sm.StartError) {
+pub fn start() -> Result(sm.Started(Msg), sm.StartError) {
   sm.new(Off, 0)
   |> sm.on_event(handle_event)
-  |> sm.start
+  |> sm.start_link
 }
 
 /// Toggle the button and return the count *before* the toggle.

--- a/examples/01-push-button/test/pushbutton_integration_test.gleam
+++ b/examples/01-push-button/test/pushbutton_integration_test.gleam
@@ -13,7 +13,8 @@ import pushbutton
 
 fn start() -> process.Subject(pushbutton.Msg) {
   let assert Ok(machine) = pushbutton.start()
-  machine.data
+  let assert Ok(subject) = sm.ref_to_subject(machine.ref)
+  subject
 }
 
 /// A freshly started pushbutton has count 0.
@@ -76,10 +77,11 @@ pub fn get_count_is_state_agnostic_test() {
 /// Casts are ignored: the handler only responds to synchronous calls.
 /// Sending a cast must leave the count untouched and produce no reply.
 pub fn cast_is_silently_ignored_test() {
-  let subject = start()
+  let assert Ok(machine) = pushbutton.start()
+  let assert Ok(subject) = sm.ref_to_subject(machine.ref)
 
   let reply_sub = process.new_subject()
-  sm.cast(subject, pushbutton.Push(reply_sub))
+  sm.cast(machine.ref, pushbutton.Push(reply_sub))
 
   // No reply arrives.
   process.receive(reply_sub, 50) |> should.equal(Error(Nil))

--- a/examples/02-door-lock/src/doorlock.gleam
+++ b/examples/02-door-lock/src/doorlock.gleam
@@ -22,9 +22,7 @@ pub type Message {
 
 // Public API
 /// Start the door lock with a 5-second auto-lock timeout.
-pub fn start(
-  code: String,
-) -> Result(sm.Started(process.Subject(Message)), sm.StartError) {
+pub fn start(code: String) -> Result(sm.Started(Message), sm.StartError) {
   start_with_lock_timeout(code, 5000)
 }
 
@@ -34,13 +32,13 @@ pub fn start(
 pub fn start_with_lock_timeout(
   code: String,
   auto_lock_ms: Int,
-) -> Result(sm.Started(process.Subject(Message)), sm.StartError) {
+) -> Result(sm.Started(Message), sm.StartError) {
   sm.new(Locked, Data(code, 0))
   |> sm.on_event(fn(event, state, data) {
     handle_event(auto_lock_ms, event, state, data)
   })
   |> sm.with_state_enter()
-  |> sm.start
+  |> sm.start_link
 }
 
 /// Send a code to the lock and wait for the result.

--- a/examples/02-door-lock/test/doorlock_integration_test.gleam
+++ b/examples/02-door-lock/test/doorlock_integration_test.gleam
@@ -10,6 +10,7 @@
 ////
 
 import doorlock
+import eparch/state_machine as sm
 import gleam/erlang/process
 import gleeunit/should
 
@@ -19,13 +20,15 @@ const code = "secret"
 /// Start a lock with the default 5-second auto-lock.
 fn start() -> process.Subject(doorlock.Message) {
   let assert Ok(machine) = doorlock.start(code)
-  machine.data
+  let assert Ok(subject) = sm.ref_to_subject(machine.ref)
+  subject
 }
 
 /// Start a lock with a short auto-lock for timeout tests.
 fn start_fast() -> process.Subject(doorlock.Message) {
   let assert Ok(machine) = doorlock.start_with_lock_timeout(code, 100)
-  machine.data
+  let assert Ok(subject) = sm.ref_to_subject(machine.ref)
+  subject
 }
 
 // Tests

--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -37,6 +37,9 @@
 //// }
 //// ```
 
+import eparch/start_options.{
+  type DebugFlag, type SpawnOption, type Timeout, Infinity,
+}
 import gleam/dynamic.{type Dynamic}
 import gleam/erlang/process.{type Monitor, type Name, type Pid}
 import gleam/option.{type Option, None, Some}
@@ -63,48 +66,6 @@ pub type StartError {
   /// Startup failed for another reason. `reason` is a human-readable string
   /// produced from the raw Erlang error term.
   StartFailed(reason: String)
-}
-
-/// A timeout: either a fixed number of milliseconds or `Infinity`.
-pub type Timeout {
-  Infinity
-  Milliseconds(ms: Int)
-}
-
-/// Process priority for `SpawnPriority`.
-pub type Priority {
-  PriorityLow
-  PriorityNormal
-  PriorityHigh
-  PriorityMax
-}
-
-/// Message queue storage mode for `SpawnMessageQueueData`.
-pub type MessageQueueMode {
-  OnHeap
-  OffHeap
-}
-
-/// Flags for the `debug` option of `StartOptions`.
-pub type DebugFlag {
-  DebugTrace
-  DebugLog
-  DebugStatistics
-  DebugLogToFile(file_name: String)
-}
-
-/// Flags for the `spawn_options` option of `StartOptions`. Subset of
-/// `erlang:spawn_opt/2`'s options that are meaningful for a long-running
-/// server process. `link` and `monitor` are intentionally omitted — the
-/// manager is always linked (and optionally monitored) by the `start` /
-/// `start_monitor` entry points themselves.
-pub type SpawnOption {
-  SpawnPriority(level: Priority)
-  SpawnFullsweepAfter(count: Int)
-  SpawnMinHeapSize(size: Int)
-  SpawnMinBinVheapSize(size: Int)
-  SpawnMaxHeapSize(size: Int)
-  SpawnMessageQueueData(mode: MessageQueueMode)
 }
 
 /// Options for `start_monitor`. Build a value with `new_start_options()` and

--- a/src/eparch/start_options.gleam
+++ b/src/eparch/start_options.gleam
@@ -1,0 +1,46 @@
+//// Shared option types for eparch behaviour modules (`state_machine` and
+//// `event_manager`). These mirror the OTP start-option surface common to
+//// `gen_statem`, `gen_event`, and `gen_server`: timeouts, debug flags, and
+//// the subset of `erlang:spawn_opt/2` options that make sense for a
+//// long-running server process.
+
+/// A timeout: either a fixed number of milliseconds or `Infinity`.
+pub type Timeout {
+  Infinity
+  Milliseconds(ms: Int)
+}
+
+/// Process priority for `SpawnPriority`.
+pub type Priority {
+  PriorityLow
+  PriorityNormal
+  PriorityHigh
+  PriorityMax
+}
+
+/// Message queue storage mode for `SpawnMessageQueueData`.
+pub type MessageQueueMode {
+  OnHeap
+  OffHeap
+}
+
+/// Flags for the `debug` start option.
+pub type DebugFlag {
+  DebugTrace
+  DebugLog
+  DebugStatistics
+  DebugLogToFile(file_name: String)
+}
+
+/// Subset of `erlang:spawn_opt/2`'s options that are meaningful for a
+/// long-running server process. `link` and `monitor` are intentionally
+/// omitted: they are decided by the lifecycle entry point (`start_link`,
+/// `start`, `start_monitor`).
+pub type SpawnOption {
+  SpawnPriority(level: Priority)
+  SpawnFullsweepAfter(count: Int)
+  SpawnMinHeapSize(size: Int)
+  SpawnMinBinVheapSize(size: Int)
+  SpawnMaxHeapSize(size: Int)
+  SpawnMessageQueueData(mode: MessageQueueMode)
+}

--- a/src/eparch/state_machine.gleam
+++ b/src/eparch/state_machine.gleam
@@ -10,9 +10,14 @@
 //// - Returns strongly-typed Steps instead of various tuple formats
 ////
 
+import eparch/start_options.{
+  type DebugFlag, type SpawnOption, type Timeout, Milliseconds,
+}
 import gleam/dynamic.{type Dynamic}
 import gleam/erlang/atom.{type Atom}
-import gleam/erlang/process.{type ExitReason, type Pid, type Subject}
+import gleam/erlang/process.{
+  type ExitReason, type Monitor, type Name, type Pid, type Subject,
+}
 import gleam/option.{type Option, None, Some}
 
 type StateEnter {
@@ -20,25 +25,51 @@ type StateEnter {
   StateEnterDisabled
 }
 
+/// A name under which a state machine can be registered.
+///
+/// Mirrors `gen_statem:server_name/0`:
+/// - `Local(name)` registers locally with `erlang:register/2` and gives back
+///   a `process.Name(message)` you can turn into a `Subject(message)`.
+/// - `Global(name)` registers across nodes via the `global` module.
+/// - `Via(module, name)` dispatches registration through any module
+///   implementing the `via` registry behaviour (e.g. `gproc`, `syn`).
+///
+pub type ServerName(message) {
+  Local(name: Name(message))
+  Global(name: Atom)
+  Via(module: Atom, name: Dynamic)
+}
+
+/// An opaque, phantom-typed handle to a running state machine.
+///
+/// Returned by `start_link`, `start`, and `start_monitor`. Accepted by
+/// `cast`, `send_request`, and `send_request_to_collection`. For unnamed and
+/// `Local`-named servers, `ref_to_subject` exposes the underlying
+/// `Subject(message)` so that `process.send`, `state_machine.send`, and
+/// `state_machine.call` can be used as well.
+///
+pub type ServerRef(message)
+
 /// A builder for configuring a state machine before starting it.
 ///
 /// Generic parameters:
 /// - `state`: The type of state values (e.g., enum, custom type)
 /// - `data`: The type of data carried across state transitions
 /// - `message`: The type of messages the state machine receives
-/// - `return`: What the start function returns to the parent
 /// - `reply`: The type of replies produced for synchronous `Call` events
 ///
-pub opaque type Builder(state, data, message, return, reply) {
+pub opaque type Builder(state, data, message, reply) {
   Builder(
     initial_state: state,
     initial_data: data,
     event_handler: fn(Event(state, message, reply), state, data) ->
       Step(state, data, message, reply),
     state_enter: StateEnter,
-    initialisation_timeout: Int,
-    name: Option(process.Name(message)),
-    hibernate_after: Option(Int),
+    timeout: Timeout,
+    hibernate_after: Timeout,
+    debug: List(DebugFlag),
+    spawn_options: List(SpawnOption),
+    name: Option(ServerName(message)),
     on_code_change: Option(fn(data) -> data),
     on_format_status: Option(
       fn(Status(state, data, message, reply)) ->
@@ -248,13 +279,21 @@ pub type NextEventType(reply) {
 pub type From(reply)
 
 /// Data returned when a state machine starts successfully.
-pub type Started(data) {
+pub type Started(message) {
   Started(
-    /// The process identifier of the started state machine
+    /// The process identifier of the started state machine.
     pid: Pid,
-    /// Data returned after initialization (typically a Subject)
-    data: data,
+    /// Opaque handle suitable for `cast`, `send_request`, etc. For unnamed
+    /// and `Local`-named starts, also convertible to a `Subject(message)`
+    /// via `ref_to_subject`.
+    ref: ServerRef(message),
   )
+}
+
+/// Data returned by `start_monitor`: a started machine plus the OTP-23+
+/// atomic monitor for it.
+pub type MonitoredMachine(message) {
+  MonitoredMachine(pid: Pid, ref: ServerRef(message), monitor: Monitor)
 }
 
 /// Errors that can occur when starting a state machine.
@@ -262,11 +301,13 @@ pub type StartError {
   InitTimeout
   InitFailed(String)
   InitExited(ExitReason)
+  /// The requested name was already registered to another process.
+  AlreadyStarted(pid: Pid)
 }
 
 /// Convenience type for start results.
-pub type StartResult(data) =
-  Result(Started(data), StartError)
+pub type StartResult(message) =
+  Result(Started(message), StartError)
 
 /// An opaque request ID returned by `send_request`.
 ///
@@ -323,29 +364,31 @@ pub type CollectionResponse(reply, label) {
 
 /// Create a new state machine builder with initial state and data.
 ///
-/// By default, the state machine will return a Subject that can be used
-/// to send messages to it.
+/// Defaults to a 1-second initialisation timeout, no idle-hibernation, no
+/// debug flags, no spawn options, and an unnamed (anonymous) registration.
 ///
 /// ## Example
 ///
 /// ```gleam
 /// state_machine.new(initial_state: Idle, initial_data: 0)
 /// |> state_machine.on_event(handle_event)
-/// |> state_machine.start
+/// |> state_machine.start_link
 /// ```
 ///
 pub fn new(
   initial_state initial_state: state,
   initial_data initial_data: data,
-) -> Builder(state, data, message, Subject(message), reply) {
+) -> Builder(state, data, message, reply) {
   Builder(
     initial_state: initial_state,
     initial_data: initial_data,
     event_handler: fn(_, _state, data) { keep_state(data, []) },
     state_enter: StateEnterDisabled,
-    initialisation_timeout: 1000,
+    timeout: Milliseconds(1000),
+    hibernate_after: start_options.Infinity,
+    debug: [],
+    spawn_options: [],
     name: None,
-    hibernate_after: None,
     on_code_change: None,
     on_format_status: None,
   )
@@ -374,14 +417,14 @@ pub fn new(
 ///
 /// state_machine.new(Running, Data(0))
 /// |> state_machine.on_event(handle_event)
-/// |> state_machine.start
+/// |> state_machine.start_link
 /// ```
 ///
 pub fn on_event(
-  builder: Builder(state, data, message, return, reply),
+  builder: Builder(state, data, message, reply),
   handler: fn(Event(state, message, reply), state, data) ->
     Step(state, data, message, reply),
-) -> Builder(state, data, message, return, reply) {
+) -> Builder(state, data, message, reply) {
   Builder(..builder, event_handler: handler)
 }
 
@@ -409,54 +452,77 @@ pub fn on_event(
 /// state_machine.new(Idle, data)
 /// |> state_machine.with_state_enter()
 /// |> state_machine.on_event(handle_event)
-/// |> state_machine.start
+/// |> state_machine.start_link
 /// ```
 ///
 pub fn with_state_enter(
-  builder: Builder(state, data, message, return, reply),
-) -> Builder(state, data, message, return, reply) {
+  builder: Builder(state, data, message, reply),
+) -> Builder(state, data, message, reply) {
   Builder(..builder, state_enter: StateEnterEnabled)
 }
 
 /// Provide a name for the state machine to be registered with when started.
 ///
-/// This enables sending messages to it via a named subject.
+/// Pass `Local(name)` for the common local-atom registration (the only form
+/// compatible with a `process.Subject`), `Global(name)` for cluster-wide
+/// registration via the `global` module, or `Via(module, term)` for a
+/// custom registry such as `gproc` or `syn`.
 ///
 pub fn named(
-  builder: Builder(state, data, message, return, reply),
-  name: process.Name(message),
-) -> Builder(state, data, message, return, reply) {
+  builder: Builder(state, data, message, reply),
+  name: ServerName(message),
+) -> Builder(state, data, message, reply) {
   Builder(..builder, name: Some(name))
 }
 
-// TODO: reject negative `milliseconds` values; gen_statem requires
-// `timeout()` (0..infinity) and will crash at start otherwise.
+/// Set the initialisation timeout. Forwarded to `gen_statem` as
+/// `{timeout, _}`. Defaults to `Milliseconds(1000)`.
+///
+pub fn with_timeout(
+  builder: Builder(state, data, message, reply),
+  timeout: Timeout,
+) -> Builder(state, data, message, reply) {
+  Builder(..builder, timeout: timeout)
+}
 
 /// Configure the [`hibernate_after`](https://www.erlang.org/doc/apps/stdlib/gen_statem.html#start_link/3)
 /// start option.
 ///
-/// When the state machine has been idle for at least `milliseconds`, the
+/// When the state machine has been idle for at least the given duration, the
 /// process hibernates (calls `proc_lib:hibernate/3`), trading a small wake-up
 /// cost for reduced memory footprint until the next event arrives. Useful for
-/// long-lived machines that spend most of their time waiting.
+/// long-lived machines that spend most of their time waiting. Defaults to
+/// `Infinity` (never hibernate).
 ///
 /// This is independent of the per-callback `Hibernate` action, which forces
 /// hibernation immediately after a single callback returns.
 ///
-/// ## Example
+pub fn with_hibernate_after(
+  builder: Builder(state, data, message, reply),
+  timeout: Timeout,
+) -> Builder(state, data, message, reply) {
+  Builder(..builder, hibernate_after: timeout)
+}
+
+/// Set the `sys` debug flags forwarded to the state machine on start.
 ///
-/// ```gleam
-/// state_machine.new(initial_state: Idle, initial_data: 0)
-/// |> state_machine.hibernate_after(60_000)
-/// |> state_machine.on_event(handle_event)
-/// |> state_machine.start
-/// ```
+pub fn with_debug(
+  builder: Builder(state, data, message, reply),
+  flags: List(DebugFlag),
+) -> Builder(state, data, message, reply) {
+  Builder(..builder, debug: flags)
+}
+
+/// Set the `erlang:spawn_opt/2` options forwarded to the state machine
+/// process on start. `link` and `monitor` are not exposed here; they are
+/// determined by the lifecycle entry point used (`start_link`, `start`,
+/// `start_monitor`).
 ///
-pub fn hibernate_after(
-  builder: Builder(state, data, message, return, reply),
-  milliseconds: Int,
-) -> Builder(state, data, message, return, reply) {
-  Builder(..builder, hibernate_after: Some(milliseconds))
+pub fn with_spawn_options(
+  builder: Builder(state, data, message, reply),
+  spawn_options: List(SpawnOption),
+) -> Builder(state, data, message, reply) {
+  Builder(..builder, spawn_options: spawn_options)
 }
 
 /// Provide a migration function called during hot-code upgrades.
@@ -477,13 +543,13 @@ pub fn hibernate_after(
 /// state_machine.new(Idle, 0)
 /// |> state_machine.on_code_change(fn(old_count) { Data(old_count, "default") })
 /// |> state_machine.on_event(handle_event)
-/// |> state_machine.start
+/// |> state_machine.start_link
 /// ```
 ///
 pub fn on_code_change(
-  builder: Builder(state, data, message, return, reply),
+  builder: Builder(state, data, message, reply),
   handler: fn(data) -> data,
-) -> Builder(state, data, message, return, reply) {
+) -> Builder(state, data, message, reply) {
   Builder(..builder, on_code_change: Some(handler))
 }
 
@@ -507,22 +573,28 @@ pub fn on_code_change(
 ///   Status(..status, data: Credentials("<redacted>"))
 /// })
 /// |> state_machine.on_event(handle_event)
-/// |> state_machine.start
+/// |> state_machine.start_link
 /// ```
 ///
 pub fn on_format_status(
-  builder: Builder(state, data, message, return, reply),
+  builder: Builder(state, data, message, reply),
   formatter: fn(Status(state, data, message, reply)) ->
     Status(state, data, message, reply),
-) -> Builder(state, data, message, return, reply) {
+) -> Builder(state, data, message, reply) {
   Builder(..builder, on_format_status: Some(formatter))
 }
 
-/// Start the state machine process.
+type LinkMode {
+  Link
+  NoLink
+}
+
+/// Start a state machine process linked to the caller.
 ///
-/// Spawns a linked gen_statem process, runs initialisation, and returns
-/// a `Started` value containing the PID and a `Subject` that can be used
-/// to send messages to the machine.
+/// Maps to `gen_statem:start_link/3,4`. Returns a `Started(message)` value
+/// containing the PID and a `ServerRef(message)`. For unnamed and `Local`-
+/// named starts, the ref is convertible to a `Subject(message)` via
+/// `ref_to_subject`.
 ///
 /// ## Example
 ///
@@ -530,58 +602,81 @@ pub fn on_format_status(
 /// let assert Ok(machine) =
 ///   state_machine.new(initial_state: Idle, initial_data: 0)
 ///   |> state_machine.on_event(handle_event)
-///   |> state_machine.start
+///   |> state_machine.start_link
 ///
-/// // Send a fire-and-forget message
-/// process.send(machine.data, SomeMessage)
-///
-/// // Send a synchronous message with a reply
-/// let reply = process.call(machine.data, 1000, SomeRequest)
+/// let assert Ok(subject) = state_machine.ref_to_subject(machine.ref)
+/// process.send(subject, SomeMessage)
 /// ```
 ///
+pub fn start_link(
+  builder: Builder(state, data, message, reply),
+) -> StartResult(message) {
+  do_start(Link, builder)
+}
+
+/// Start a state machine process without linking it to the caller.
+///
+/// Maps to `gen_statem:start/3,4`. Useful when the parent does not want a
+/// link-based crash propagation, e.g. when the parent will set up its own
+/// monitor or when the machine is started under a custom supervisor.
+///
 pub fn start(
-  builder: Builder(state, data, message, Subject(message), reply),
-) -> StartResult(Subject(message)) {
-  let Builder(
-    initial_state:,
-    initial_data:,
-    event_handler:,
-    state_enter:,
-    initialisation_timeout:,
-    name:,
-    hibernate_after:,
-    on_code_change:,
-    on_format_status:,
-  ) = builder
-  do_start(
-    initial_state,
-    initial_data,
-    event_handler,
-    state_enter,
-    initialisation_timeout,
-    name,
-    hibernate_after,
-    on_code_change,
-    on_format_status,
-  )
+  builder: Builder(state, data, message, reply),
+) -> StartResult(message) {
+  do_start(NoLink, builder)
+}
+
+/// Start a state machine process linked to the caller and atomically return
+/// a monitor for it.
+///
+/// Maps to `gen_statem:start_monitor/3,4` (OTP 23.0+). Equivalent to
+/// `start_link` followed by `process.monitor`, but without the race window
+/// between the two calls.
+///
+pub fn start_monitor(
+  builder: Builder(state, data, message, reply),
+) -> Result(MonitoredMachine(message), StartError) {
+  do_start_monitor(builder)
 }
 
 @external(erlang, "statem_ffi", "do_start")
 fn do_start(
-  initial_state: state,
-  initial_data: data,
-  event_handler: fn(Event(state, message, reply), state, data) ->
-    Step(state, data, message, reply),
-  state_enter: StateEnter,
-  initialisation_timeout: Int,
-  name: Option(process.Name(message)),
-  hibernate_after: Option(Int),
-  on_code_change: Option(fn(data) -> data),
-  on_format_status: Option(
-    fn(Status(state, data, message, reply)) ->
-      Status(state, data, message, reply),
-  ),
-) -> Result(Started(Subject(message)), StartError)
+  link_mode: LinkMode,
+  builder: Builder(state, data, message, reply),
+) -> StartResult(message)
+
+@external(erlang, "statem_ffi", "do_start_monitor")
+fn do_start_monitor(
+  builder: Builder(state, data, message, reply),
+) -> Result(MonitoredMachine(message), StartError)
+
+/// Extract the `Subject(message)` underlying a `ServerRef(message)`.
+///
+/// Succeeds for refs returned by unnamed starts and `Local`-named starts.
+/// Returns `Error(Nil)` for refs registered through `Global` or `Via`,
+/// because those servers cannot be addressed by a `Subject`: they live
+/// outside the local-atom name table.
+///
+@external(erlang, "statem_ffi", "ref_to_subject")
+pub fn ref_to_subject(ref: ServerRef(message)) -> Result(Subject(message), Nil)
+
+/// Wrap an existing `Subject(message)` as a `ServerRef(message)`.
+///
+/// Useful when a state machine's subject is already in hand (e.g. captured
+/// during start) and it needs to be passed to a function that expects a
+/// `ServerRef`.
+///
+@external(erlang, "statem_ffi", "ref_from_subject")
+pub fn ref_from_subject(subject: Subject(message)) -> ServerRef(message)
+
+/// Wrap a raw `Pid` as a `ServerRef(message)`.
+///
+/// The phantom `message` parameter is unchecked; callers are responsible
+/// for passing the correct type. Use only when the Pid is known to belong
+/// to an eparch state machine handling messages of the expected type.
+///
+@external(erlang, "statem_ffi", "ref_from_pid")
+pub fn ref_from_pid(pid: Pid) -> ServerRef(message)
 
 /// Create a NextState step indicating a state transition.
 ///
@@ -877,7 +972,7 @@ pub fn send(subject: Subject(message), message: message) -> Nil {
 /// ```
 ///
 @external(erlang, "statem_ffi", "cast")
-pub fn cast(subject: Subject(message), message: message) -> Nil
+pub fn cast(ref: ServerRef(message), message: message) -> Nil
 
 /// Send a synchronous call and wait for a reply.
 ///
@@ -940,13 +1035,13 @@ pub fn request_ids_to_list(
 /// and must reply with a `Reply(from, value)` action.
 ///
 /// The `reply` type cannot always be inferred, so annotate the binding when
-/// needed: `let request: RequestId(MyReply) = send_request(subject, MyMsg)`
+/// needed: `let request: RequestId(MyReply) = send_request(machine.ref, MyMsg)`
 ///
 /// ## Example
 ///
 /// ```gleam
 /// let request: state_machine.RequestId(Int) =
-///   state_machine.send_request(machine.data, GetCount)
+///   state_machine.send_request(machine.ref, GetCount)
 /// // ... do other work ...
 /// let assert Ok(count) = state_machine.receive_response(request, 1000)
 /// ```
@@ -955,7 +1050,7 @@ pub fn request_ids_to_list(
 ///
 @external(erlang, "statem_ffi", "send_request")
 pub fn send_request(
-  subject: Subject(message),
+  ref: ServerRef(message),
   message: message,
 ) -> RequestId(reply)
 
@@ -982,7 +1077,7 @@ pub fn send_request(
 ///
 @external(erlang, "statem_ffi", "send_request_to_collection")
 pub fn send_request_to_collection(
-  subject: Subject(message),
+  ref: ServerRef(message),
   message: message,
   label: label,
   to collection: RequestIdCollection(label, reply),

--- a/src/eparch_options_ffi.erl
+++ b/src/eparch_options_ffi.erl
@@ -1,0 +1,65 @@
+-module(eparch_options_ffi).
+-moduledoc """
+Shared encoders for the start-option types defined in `eparch/start_options`.
+Used by both `statem_ffi` and `event_manager_ffi` so the Gleam-to-Erlang
+mapping for `Timeout`, `DebugFlag`, `SpawnOption`, `Priority`, and
+`MessageQueueMode` lives in exactly one place.
+""".
+
+-export([
+    timeout_to_erlang/1,
+    debug_to_erlang/1,
+    spawn_opt_to_erlang/1,
+    priority_to_erlang/1,
+    mq_mode_to_erlang/1,
+    build_extra_opts/2
+]).
+
+-doc "Converts a Gleam `Timeout` to an Erlang `timeout()` value.".
+timeout_to_erlang(infinity) -> infinity;
+timeout_to_erlang({milliseconds, Ms}) -> Ms.
+
+-doc "Converts a Gleam `DebugFlag` to an Erlang `sys:dbg_opt()` term.".
+debug_to_erlang(debug_trace) -> trace;
+debug_to_erlang(debug_log) -> log;
+debug_to_erlang(debug_statistics) -> statistics;
+debug_to_erlang({debug_log_to_file, FileName}) -> {log_to_file, FileName}.
+
+-doc "Converts a Gleam `SpawnOption` to an Erlang `spawn_opt/2` option.".
+spawn_opt_to_erlang({spawn_priority, Level}) ->
+    {priority, priority_to_erlang(Level)};
+spawn_opt_to_erlang({spawn_fullsweep_after, N}) ->
+    {fullsweep_after, N};
+spawn_opt_to_erlang({spawn_min_heap_size, N}) ->
+    {min_heap_size, N};
+spawn_opt_to_erlang({spawn_min_bin_vheap_size, N}) ->
+    {min_bin_vheap_size, N};
+spawn_opt_to_erlang({spawn_max_heap_size, N}) ->
+    {max_heap_size, N};
+spawn_opt_to_erlang({spawn_message_queue_data, Mode}) ->
+    {message_queue_data, mq_mode_to_erlang(Mode)}.
+
+-doc "Converts a Gleam `Priority` atom to its Erlang counterpart.".
+priority_to_erlang(priority_low) -> low;
+priority_to_erlang(priority_normal) -> normal;
+priority_to_erlang(priority_high) -> high;
+priority_to_erlang(priority_max) -> max.
+
+-doc "Converts a Gleam `MessageQueueMode` atom to its Erlang counterpart.".
+mq_mode_to_erlang(on_heap) -> on_heap;
+mq_mode_to_erlang(off_heap) -> off_heap.
+
+-doc """
+Build the optional `[{debug, _}, {spawn_opt, _}]` tail of a behaviour's
+start-option list. Empty lists are skipped so unused options are not present
+in the result.
+""".
+build_extra_opts(DebugFlags, SpawnOpts) ->
+    case DebugFlags of
+        [] -> [];
+        _ -> [{debug, [debug_to_erlang(F) || F <- DebugFlags]}]
+    end ++
+        case SpawnOpts of
+            [] -> [];
+            _ -> [{spawn_opt, [spawn_opt_to_erlang(O) || O <- SpawnOpts]}]
+        end.

--- a/src/event_manager_ffi.erl
+++ b/src/event_manager_ffi.erl
@@ -116,48 +116,14 @@ do_start_monitor({start_options, NameOpt, Timeout, HibernateAfter, DebugFlags, S
     end.
 
 build_start_opts(Timeout, HibernateAfter, DebugFlags, SpawnOpts) ->
-    [{timeout, timeout_to_erlang(Timeout)}, {hibernate_after, timeout_to_erlang(HibernateAfter)}] ++
-        case DebugFlags of
-            [] -> [];
-            _ -> [{debug, [debug_to_erlang(F) || F <- DebugFlags]}]
-        end ++
-        case SpawnOpts of
-            [] -> [];
-            _ -> [{spawn_opt, [spawn_opt_to_erlang(O) || O <- SpawnOpts]}]
-        end.
-
-timeout_to_erlang(infinity) -> infinity;
-timeout_to_erlang({milliseconds, Ms}) -> Ms.
-
-debug_to_erlang(debug_trace) -> trace;
-debug_to_erlang(debug_log) -> log;
-debug_to_erlang(debug_statistics) -> statistics;
-debug_to_erlang({debug_log_to_file, FileName}) -> {log_to_file, FileName}.
-
-spawn_opt_to_erlang({spawn_priority, Level}) ->
-    {priority, priority_to_erlang(Level)};
-spawn_opt_to_erlang({spawn_fullsweep_after, N}) ->
-    {fullsweep_after, N};
-spawn_opt_to_erlang({spawn_min_heap_size, N}) ->
-    {min_heap_size, N};
-spawn_opt_to_erlang({spawn_min_bin_vheap_size, N}) ->
-    {min_bin_vheap_size, N};
-spawn_opt_to_erlang({spawn_max_heap_size, N}) ->
-    {max_heap_size, N};
-spawn_opt_to_erlang({spawn_message_queue_data, Mode}) ->
-    {message_queue_data, mq_mode_to_erlang(Mode)}.
+    [
+        {timeout, eparch_options_ffi:timeout_to_erlang(Timeout)},
+        {hibernate_after, eparch_options_ffi:timeout_to_erlang(HibernateAfter)}
+    ] ++ eparch_options_ffi:build_extra_opts(DebugFlags, SpawnOpts).
 
 %% Render an Erlang error term as a human-readable Gleam string.
 format_reason(Reason) ->
     unicode:characters_to_binary(io_lib:format("~p", [Reason])).
-
-priority_to_erlang(priority_low) -> low;
-priority_to_erlang(priority_normal) -> normal;
-priority_to_erlang(priority_high) -> high;
-priority_to_erlang(priority_max) -> max.
-
-mq_mode_to_erlang(on_heap) -> on_heap;
-mq_mode_to_erlang(off_heap) -> off_heap.
 
 -doc """
 Stop the event manager, terminating it with reason `normal`.

--- a/src/statem_ffi.erl
+++ b/src/statem_ffi.erl
@@ -7,7 +7,14 @@ gen_statem behavior callbacks and Gleam's type-safe API.
 -behaviour(gen_statem).
 
 %% Public API
--export([do_start/9, cast/2]).
+-export([
+    do_start/2,
+    do_start_monitor/1,
+    cast/2,
+    ref_to_subject/1,
+    ref_from_subject/1,
+    ref_from_pid/1
+]).
 -export([
     stop_server/1,
     stop_server_with/3,
@@ -42,8 +49,14 @@ gen_statem behavior callbacks and Gleam's type-safe API.
 %%%===================================================================
 %%% Internal State Records & Types
 %%%===================================================================
--type process_name_option() :: none | {some, Name :: string()}.
--type state_enter_option() :: state_enter_disabled | state_enter_enabled.
+%% Gleam-side `ServerName(message)` ADT, encoded as the same tuple shape
+%% gen_statem expects, so the value can be passed straight to OTP.
+-type server_name_option() ::
+    none
+    | {some,
+        {local, atom()}
+        | {global, atom()}
+        | {via, atom(), term()}}.
 
 -record(gleam_statem, {
     % Current Gleam state value
@@ -69,93 +82,99 @@ gen_statem behavior callbacks and Gleam's type-safe API.
 %%% called from Gleam via @external
 %%%===================================================================
 -doc """
-Start a `gen_statem` process linked to the caller and return the Subject
-needed to send messages to it
+Start a `gen_statem` process either linked (`link`) or unlinked (`no_link`).
+
+The Gleam side passes a `LinkMode` selector and the opaque `Builder` record;
+the latter is encoded at the Erlang level as the 12-tuple defined in
+`eparch/state_machine`. Returns the Gleam `Started(message)` 3-tuple
+`{started, Pid, ServerRef}` or a mapped error.
 """.
--spec do_start(
-    InitialState,
-    InitialData,
-    Handler,
-    StateEnter,
-    TimeOut,
-    Name,
-    HibernateAfter,
-    OnCodeChange,
-    OnFormatStatus
-) ->
-    Result
-when
-    InitialState :: any(),
-    InitialData :: any(),
-    Handler :: any(),
-    StateEnter :: state_enter_option(),
-    TimeOut :: timeout(),
-    Name :: process_name_option(),
-    HibernateAfter :: none | {some, non_neg_integer()},
-    OnCodeChange :: any(),
-    OnFormatStatus :: any(),
+-spec do_start(LinkMode, Builder) -> Result when
+    LinkMode :: link | no_link,
+    Builder :: tuple(),
     Result :: any().
-do_start(
-    InitialState,
-    InitialData,
-    Handler,
-    StateEnter,
-    Timeout,
-    Name,
-    HibernateAfter,
-    OnCodeChange,
-    OnFormatStatus
-) ->
-    %% Ack channel: a unique reference the child process will use to
-    %% send us the Subject it creates in init/1.
+do_start(LinkMode, Builder) ->
+    {AckTag, InitArgs, ExtraOpts, NameOpt} = unpack_builder(Builder),
+    StartResult = invoke_start(LinkMode, NameOpt, InitArgs, ExtraOpts),
+    handle_start_result(StartResult, AckTag).
+
+-doc """
+Start a `gen_statem` process linked to the caller with an atomic monitor
+(OTP 23.0+). Returns the Gleam `MonitoredMachine(message)` 4-tuple
+`{monitored_machine, Pid, ServerRef, MonitorRef}` or a mapped error.
+""".
+-spec do_start_monitor(Builder) -> Result when
+    Builder :: tuple(),
+    Result :: any().
+do_start_monitor(Builder) ->
+    {AckTag, InitArgs, ExtraOpts, NameOpt} = unpack_builder(Builder),
+    StartResult = invoke_start(atomic_monitor, NameOpt, InitArgs, ExtraOpts),
+    handle_monitor_start_result(StartResult, AckTag).
+
+%% --- builder unpacking ----------------------------------------------------
+
+-spec unpack_builder(tuple()) -> {reference(), tuple(), [term()], server_name_option()}.
+unpack_builder(Builder) ->
+    {builder, InitialState, InitialData, Handler, StateEnter, Timeout, HibernateAfter, Debug,
+        SpawnOpts, NameOpt, OnCodeChange, OnFormatStatus} = Builder,
     AckTag = make_ref(),
     Parent = self(),
-
     InitArgs =
-        {init_args, InitialState, InitialData, Handler, StateEnter, Parent, AckTag, Name,
+        {init_args, InitialState, InitialData, Handler, StateEnter, Parent, AckTag, NameOpt,
             OnCodeChange, OnFormatStatus},
+    ExtraOpts =
+        [
+            {timeout, eparch_options_ffi:timeout_to_erlang(Timeout)},
+            {hibernate_after, eparch_options_ffi:timeout_to_erlang(HibernateAfter)}
+        ] ++ eparch_options_ffi:build_extra_opts(Debug, SpawnOpts),
+    {AckTag, InitArgs, ExtraOpts, NameOpt}.
 
-    BaseOpts = [{timeout, Timeout}],
-    Opts =
-        case HibernateAfter of
-            none -> BaseOpts;
-            {some, Ms} -> [{hibernate_after, Ms} | BaseOpts]
-        end,
+-spec invoke_start(link | no_link | atomic_monitor, server_name_option(), tuple(), [term()]) ->
+    {ok, pid()} | {ok, {pid(), reference()}} | {error, term()}.
+invoke_start(link, none, InitArgs, Opts) ->
+    gen_statem:start_link(?MODULE, InitArgs, Opts);
+invoke_start(link, {some, ServerName}, InitArgs, Opts) ->
+    gen_statem:start_link(ServerName, ?MODULE, InitArgs, Opts);
+invoke_start(no_link, none, InitArgs, Opts) ->
+    gen_statem:start(?MODULE, InitArgs, Opts);
+invoke_start(no_link, {some, ServerName}, InitArgs, Opts) ->
+    gen_statem:start(ServerName, ?MODULE, InitArgs, Opts);
+invoke_start(atomic_monitor, none, InitArgs, Opts) ->
+    gen_statem:start_monitor(?MODULE, InitArgs, Opts);
+invoke_start(atomic_monitor, {some, ServerName}, InitArgs, Opts) ->
+    gen_statem:start_monitor(ServerName, ?MODULE, InitArgs, Opts).
 
-    StartResult =
-        case Name of
-            none ->
-                gen_statem:start_link(?MODULE, InitArgs, Opts);
-            {some, ProcessName} ->
-                gen_statem:start_link(
-                    %% TODO: Change this to support other formats
-                    %% https://www.erlang.org/doc/apps/stdlib/gen_statem.html#t:server_name/0
-                    {local, ProcessName},
-                    ?MODULE,
-                    InitArgs,
-                    Opts
-                )
-        end,
+handle_start_result({ok, Pid}, AckTag) when is_pid(Pid) ->
+    case await_init_ack(AckTag) of
+        {ok, ServerRef} -> {ok, {started, Pid, ServerRef}};
+        Error -> Error
+    end;
+handle_start_result(Error, _AckTag) ->
+    classify_start_error(Error).
 
-    case StartResult of
-        {ok, Pid} ->
-            %% init/1 runs synchronously inside start_link, so the Subject
-            %% is already waiting in our mailbox. Use after 0 as a safety net,
-            %% in practice the message is always there.
-            receive
-                {AckTag, Subject} ->
-                    {ok, {started, Pid, Subject}}
-            after 0 ->
-                %% Should "never" happen, indicates a bug in init/1.
-                {error, {init_failed, <<"init/1 did not deliver a Subject">>}}
-            end;
-        {error, timeout} ->
-            {error, init_timeout};
-        {error, {already_started, _OtherPid}} ->
-            {error, {init_failed, <<"process name already registered">>}};
-        {error, Reason} ->
-            {error, {init_exited, {abnormal, Reason}}}
+handle_monitor_start_result({ok, {Pid, MonRef}}, AckTag) when is_pid(Pid) ->
+    case await_init_ack(AckTag) of
+        {ok, ServerRef} -> {ok, {monitored_machine, Pid, ServerRef, MonRef}};
+        Error -> Error
+    end;
+handle_monitor_start_result(Error, _AckTag) ->
+    classify_start_error(Error).
+
+await_init_ack(AckTag) ->
+    %% init/1 runs synchronously inside start_link/start/start_monitor, so
+    %% the ServerRef is already in our mailbox by the time we get here.
+    receive
+        {AckTag, ServerRef} -> {ok, ServerRef}
+    after 0 ->
+        {error, {init_failed, <<"init/1 did not deliver a ServerRef">>}}
     end.
+
+classify_start_error({error, timeout}) ->
+    {error, init_timeout};
+classify_start_error({error, {already_started, OtherPid}}) when is_pid(OtherPid) ->
+    {error, {already_started, OtherPid}};
+classify_start_error({error, Reason}) ->
+    {error, {init_exited, {abnormal, Reason}}}.
 
 %%%===================================================================
 %%% gen_statem callbacks
@@ -170,22 +189,17 @@ init(
     {init_args, InitialState, InitialData, Handler, StateEnter, Parent, AckTag, Name, OnCodeChange,
         OnFormatStatus}
 ) ->
-    %% Build the Subject and determine the tag used for message unwrapping.
-    {Subject, SubjectTag} =
-        case Name of
-            none ->
-                %% Unnamed process: tag is a unique reference, subject is the
-                %% standard {subject, Pid, Tag} Gleam variant.
-                Tag = make_ref(),
-                {{subject, self(), Tag}, Tag};
-            {some, ProcessName} ->
-                %% Named process: tag is the atom, subject is the
-                %% {named_subject, Name} Gleam variant.
-                {{named_subject, ProcessName}, ProcessName}
-        end,
+    %% Build the ServerRef and determine the tag used for info-message
+    %% unwrapping. For unnamed and Local-named servers the ref carries a
+    %% Subject, so the tag matches what callers send via process.send. For
+    %% Global/Via, no Subject is associated, but we still pick a fresh
+    %% reference as the tag so unrelated info messages always pass through
+    %% raw (the ref will never collide with an external sender).
+    {ServerRef, SubjectTag} = build_server_ref(Name),
 
-    %% Send the Subject to the parent before gen_statem unblocks start_link.
-    Parent ! {AckTag, Subject},
+    %% Send the ServerRef to the parent before gen_statem unblocks the
+    %% start* call.
+    Parent ! {AckTag, ServerRef},
 
     GleamStatem = #gleam_statem{
         gleam_state = InitialState,
@@ -198,6 +212,17 @@ init(
     },
 
     {ok, InitialState, GleamStatem}.
+
+-spec build_server_ref(server_name_option()) -> {tuple(), term()}.
+build_server_ref(none) ->
+    Tag = make_ref(),
+    {{server_ref_subject, {subject, self(), Tag}}, Tag};
+build_server_ref({some, {local, NameAtom}}) ->
+    {{server_ref_subject, {named_subject, NameAtom}}, NameAtom};
+build_server_ref({some, {global, GlobalName}}) ->
+    {{server_ref_global, GlobalName}, make_ref()};
+build_server_ref({some, {via, Mod, Term}}) ->
+    {{server_ref_via, Mod, Term}, make_ref()}.
 
 -doc """
 Always advertise `handle_event_function` + `state_enter`.
@@ -574,15 +599,45 @@ subject_to_pid({named_subject, Name}) ->
     end.
 
 -doc """
-Sends an asynchronous `cast` to a running `gen_statem` process.
+Sends an asynchronous `cast` to a running `gen_statem` via its `ServerRef`.
 
-Extracts the `Pid` from the Gleam Subject and calls `gen_statem:cast/2`.
-The message arrives in `handle_event/4` with `EventType=cast` and is
-converted to `Cast(Msg)` for the Gleam handler.
+Resolves the ref to the appropriate `gen_statem`-compatible target and calls
+`gen_statem:cast/2`. The message arrives in `handle_event/4` with
+`EventType=cast` and is converted to `Cast(Msg)` for the Gleam handler.
 """.
-cast(Subject, Msg) ->
-    gen_statem:cast(subject_to_pid(Subject), Msg),
+cast(ServerRef, Msg) ->
+    gen_statem:cast(ref_target(ServerRef), Msg),
     nil.
+
+-doc """
+Resolve a `ServerRef` to the target shape accepted by `gen_statem:cast/2`,
+`gen_statem:call/3`, and `gen_statem:send_request/2`.
+""".
+-spec ref_target(tuple()) -> pid() | atom() | {global, atom()} | {via, atom(), term()}.
+ref_target({server_ref_subject, {subject, Pid, _Tag}}) -> Pid;
+ref_target({server_ref_subject, {named_subject, Name}}) -> Name;
+ref_target({server_ref_global, Name}) -> {global, Name};
+ref_target({server_ref_via, Mod, Term}) -> {via, Mod, Term};
+ref_target({server_ref_pid, Pid}) -> Pid.
+
+-doc """
+Extract the `Subject(message)` underlying a `ServerRef`. Succeeds for refs
+returned by unnamed and `Local`-named starts; returns `{error, nil}` for
+`Global`, `Via`, or raw-Pid refs.
+""".
+-spec ref_to_subject(tuple()) -> {ok, tuple()} | {error, nil}.
+ref_to_subject({server_ref_subject, Subject}) -> {ok, Subject};
+ref_to_subject(_) -> {error, nil}.
+
+-doc "Wrap an existing Gleam `Subject(message)` as a `ServerRef(message)`.".
+ref_from_subject(Subject) -> {server_ref_subject, Subject}.
+
+-doc """
+Wrap a raw `Pid` as a `ServerRef(message)`. Suitable for `cast` and
+`send_request`; not convertible back to a `Subject` because no subject tag
+is associated.
+""".
+ref_from_pid(Pid) when is_pid(Pid) -> {server_ref_pid, Pid}.
 
 -doc "Stop a running state machine with reason `normal`.".
 stop_server(Subject) ->
@@ -668,25 +723,15 @@ request id. The server receives a `Call(from, msg)` event and must respond
 with a `Reply(from, value)` action. Use `receive_response/2` to collect the
 reply when ready.
 """.
-send_request({subject, Pid, _Tag}, Msg) ->
-    gen_statem:send_request(Pid, Msg);
-send_request({named_subject, Name}, Msg) ->
-    case erlang:whereis(Name) of
-        Pid when is_pid(Pid) -> gen_statem:send_request(Pid, Msg);
-        undefined -> error({noproc, Name})
-    end.
+send_request(ServerRef, Msg) ->
+    gen_statem:send_request(ref_target(ServerRef), Msg).
 
 -doc """
 Like `send_request/2` but also adds the resulting request id (under `Label`)
 to `Collection`, returning the updated collection.
 """.
-send_request_to_collection({subject, Pid, _Tag}, Msg, Label, Collection) ->
-    gen_statem:send_request(Pid, Msg, Label, Collection);
-send_request_to_collection({named_subject, Name}, Msg, Label, Collection) ->
-    case erlang:whereis(Name) of
-        Pid when is_pid(Pid) -> gen_statem:send_request(Pid, Msg, Label, Collection);
-        undefined -> error({noproc, Name})
-    end.
+send_request_to_collection(ServerRef, Msg, Label, Collection) ->
+    gen_statem:send_request(ref_target(ServerRef), Msg, Label, Collection).
 
 -doc """
 Waits up to `Timeout` milliseconds for the reply to a single `ReqId`.

--- a/test/actions_test.gleam
+++ b/test/actions_test.gleam
@@ -6,6 +6,7 @@
 //// name collisions across sections.
 ////
 
+import eparch/start_options
 import eparch/state_machine
 import gleam/dynamic.{type Dynamic}
 import gleam/erlang/atom
@@ -21,6 +22,16 @@ fn sys_get_status(pid: process.Pid) -> Dynamic
 
 @external(erlang, "erlang", "process_info")
 fn process_info(pid: process.Pid, key: atom.Atom) -> Dynamic
+
+/// Test helper: extract the underlying Subject from a Started machine.
+/// Tests in this module only use unnamed and Local-named starts, so this
+/// always succeeds; the assertion documents that assumption.
+fn subject_of(
+  machine: state_machine.Started(message),
+) -> process.Subject(message) {
+  let assert Ok(s) = state_machine.ref_to_subject(machine.ref)
+  s
+}
 
 // STOP
 type StopState {
@@ -46,14 +57,14 @@ pub fn stop_normal_terminates_process_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: StopRunning, initial_data: Nil)
     |> state_machine.on_event(stop_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let monitor = process.monitor(machine.pid)
   let selector =
     process.new_selector()
     |> process.select_specific_monitor(monitor, fn(down) { down })
 
-  process.send(machine.data, Shutdown)
+  process.send(subject_of(machine), Shutdown)
 
   let assert Ok(down) = process.selector_receive(selector, 1000)
   down.reason |> should.equal(process.Normal)
@@ -95,12 +106,12 @@ pub fn postpone_redelivers_event_after_state_change_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: PostWaiting, initial_data: Nil)
     |> state_machine.on_event(postpone_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let reply_sub = process.new_subject()
   // Action arrives first but is postponed; Go triggers state change -> redeliver.
-  process.send(machine.data, Action(reply_with: reply_sub))
-  process.send(machine.data, Go)
+  process.send(subject_of(machine), Action(reply_with: reply_sub))
+  process.send(subject_of(machine), Go)
 
   let assert Ok(reply) = process.receive(reply_sub, 1000)
   reply |> should.equal("handled")
@@ -143,10 +154,10 @@ pub fn next_event_fires_synthesised_cast_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: NeActive, initial_data: Nil)
     |> state_machine.on_event(next_event_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let reply_sub = process.new_subject()
-  process.send(machine.data, Trigger(reply_with: reply_sub))
+  process.send(subject_of(machine), Trigger(reply_with: reply_sub))
 
   let assert Ok(reply) = process.receive(reply_sub, 1000)
   reply |> should.equal("derived")
@@ -189,13 +200,13 @@ pub fn state_timeout_fires_and_transitions_state_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: StIdle, initial_data: Nil)
     |> state_machine.on_event(state_timeout_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
-  process.send(machine.data, StActivate)
+  process.send(subject_of(machine), StActivate)
   process.sleep(30)
 
   let reply_sub = process.new_subject()
-  process.send(machine.data, StGetState(reply_with: reply_sub))
+  process.send(subject_of(machine), StGetState(reply_with: reply_sub))
 
   let assert Ok(s) = process.receive(reply_sub, 1000)
   s |> should.equal(StTimedOut)
@@ -239,13 +250,13 @@ pub fn state_timeout_is_cancelled_on_state_change_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: CIdle, initial_data: Nil)
     |> state_machine.on_event(cancel_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
-  process.send(machine.data, CActivate)
-  process.send(machine.data, CLeave)
+  process.send(subject_of(machine), CActivate)
+  process.send(subject_of(machine), CLeave)
 
   let reply_sub = process.new_subject()
-  process.send(machine.data, CGetState(reply_with: reply_sub))
+  process.send(subject_of(machine), CGetState(reply_with: reply_sub))
   let assert Ok(s) = process.receive(reply_sub, 1000)
   s |> should.equal(CDone)
 }
@@ -286,13 +297,13 @@ pub fn generic_timeout_fires_after_interval_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: GtWaiting, initial_data: Nil)
     |> state_machine.on_event(generic_timeout_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
-  process.send(machine.data, GtArm)
+  process.send(subject_of(machine), GtArm)
   process.sleep(30)
 
   let reply_sub = process.new_subject()
-  process.send(machine.data, GtGetState(reply_with: reply_sub))
+  process.send(subject_of(machine), GtGetState(reply_with: reply_sub))
   let assert Ok(s) = process.receive(reply_sub, 1000)
   s |> should.equal(GtTriggered)
 }
@@ -339,14 +350,14 @@ pub fn cancel_state_timeout_prevents_fire_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: CstIdle, initial_data: Nil)
     |> state_machine.on_event(cancel_state_timeout_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
-  process.send(machine.data, CstActivate)
-  process.send(machine.data, CstCancel)
+  process.send(subject_of(machine), CstActivate)
+  process.send(subject_of(machine), CstCancel)
   process.sleep(30)
 
   let reply_sub = process.new_subject()
-  process.send(machine.data, CstGetState(reply_with: reply_sub))
+  process.send(subject_of(machine), CstGetState(reply_with: reply_sub))
   let assert Ok(s) = process.receive(reply_sub, 1000)
   s |> should.equal(CstActive)
 }
@@ -394,14 +405,14 @@ pub fn cancel_generic_timeout_prevents_fire_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: CgtWaiting, initial_data: Nil)
     |> state_machine.on_event(cancel_generic_timeout_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
-  process.send(machine.data, CgtArm)
-  process.send(machine.data, CgtCancel)
+  process.send(subject_of(machine), CgtArm)
+  process.send(subject_of(machine), CgtCancel)
   process.sleep(30)
 
   let reply_sub = process.new_subject()
-  process.send(machine.data, CgtGetState(reply_with: reply_sub))
+  process.send(subject_of(machine), CgtGetState(reply_with: reply_sub))
   let assert Ok(s) = process.receive(reply_sub, 1000)
   s |> should.equal(CgtWaiting)
 }
@@ -447,14 +458,14 @@ pub fn update_state_timeout_fires_without_restart_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: UstWaiting, initial_data: Nil)
     |> state_machine.on_event(update_state_timeout_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
-  process.send(machine.data, UstArm)
-  process.send(machine.data, UstUpdate)
+  process.send(subject_of(machine), UstArm)
+  process.send(subject_of(machine), UstUpdate)
   process.sleep(300)
 
   let reply_sub = process.new_subject()
-  process.send(machine.data, UstGetState(reply_with: reply_sub))
+  process.send(subject_of(machine), UstGetState(reply_with: reply_sub))
   let assert Ok(s) = process.receive(reply_sub, 1000)
   s |> should.equal(UstFired)
 }
@@ -490,10 +501,10 @@ pub fn cast_delivers_message_as_cast_event_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: CastListening, initial_data: Nil)
     |> state_machine.on_event(cast_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let reply_sub = process.new_subject()
-  state_machine.cast(machine.data, Ping(reply_with: reply_sub))
+  state_machine.cast(machine.ref, Ping(reply_with: reply_sub))
 
   let assert Ok(reply) = process.receive(reply_sub, 1000)
   reply |> should.equal("pong")
@@ -505,10 +516,10 @@ pub fn send_delivers_message_as_info_not_cast_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: CastListening, initial_data: Nil)
     |> state_machine.on_event(cast_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let reply_sub = process.new_subject()
-  state_machine.send(machine.data, Ping(reply_with: reply_sub))
+  state_machine.send(subject_of(machine), Ping(reply_with: reply_sub))
 
   process.receive(reply_sub, 50) |> should.equal(Error(Nil))
 }
@@ -550,12 +561,12 @@ pub fn change_callback_module_keeps_machine_alive_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: CbListening, initial_data: Nil)
     |> state_machine.on_event(change_callback_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
-  process.send(machine.data, CbSwitch)
+  process.send(subject_of(machine), CbSwitch)
 
   let reply_sub = process.new_subject()
-  process.send(machine.data, CbPing(reply_with: reply_sub))
+  process.send(subject_of(machine), CbPing(reply_with: reply_sub))
 
   let assert Ok(reply) = process.receive(reply_sub, 1000)
   reply |> should.equal("pong")
@@ -587,12 +598,12 @@ pub fn push_then_pop_callback_module_roundtrip_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: CbListening, initial_data: Nil)
     |> state_machine.on_event(push_pop_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
-  process.send(machine.data, CbSwitch)
+  process.send(subject_of(machine), CbSwitch)
 
   let reply_sub = process.new_subject()
-  process.send(machine.data, CbPing(reply_with: reply_sub))
+  process.send(subject_of(machine), CbPing(reply_with: reply_sub))
 
   let assert Ok(reply) = process.receive(reply_sub, 1000)
   reply |> should.equal("pong")
@@ -631,10 +642,10 @@ pub fn send_request_returns_reply_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ReqRunning, initial_data: 0)
     |> state_machine.on_event(reqid_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let request: state_machine.RequestId(Int) =
-    state_machine.send_request(machine.data, GetCounter)
+    state_machine.send_request(machine.ref, GetCounter)
   let assert Ok(count) = state_machine.receive_response(request, 1000)
   count |> should.equal(0)
 }
@@ -643,13 +654,13 @@ pub fn send_request_sees_latest_state_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ReqRunning, initial_data: 0)
     |> state_machine.on_event(reqid_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
-  process.send(machine.data, Increment)
-  process.send(machine.data, Increment)
+  process.send(subject_of(machine), Increment)
+  process.send(subject_of(machine), Increment)
 
   let request: state_machine.RequestId(Int) =
-    state_machine.send_request(machine.data, GetCounter)
+    state_machine.send_request(machine.ref, GetCounter)
   let assert Ok(count) = state_machine.receive_response(request, 1000)
   count |> should.equal(2)
 }
@@ -658,7 +669,7 @@ pub fn request_ids_size_reflects_pending_requests_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ReqRunning, initial_data: 0)
     |> state_machine.on_event(reqid_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let collection: state_machine.RequestIdCollection(String, Int) =
     state_machine.request_ids_new()
@@ -666,7 +677,7 @@ pub fn request_ids_size_reflects_pending_requests_test() {
 
   let collection =
     state_machine.send_request_to_collection(
-      machine.data,
+      machine.ref,
       GetCounter,
       "first",
       collection,
@@ -675,7 +686,7 @@ pub fn request_ids_size_reflects_pending_requests_test() {
 
   let collection =
     state_machine.send_request_to_collection(
-      machine.data,
+      machine.ref,
       GetCounter,
       "second",
       collection,
@@ -701,20 +712,20 @@ pub fn send_request_to_collection_delivers_both_replies_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ReqRunning, initial_data: 42)
     |> state_machine.on_event(reqid_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let collection: state_machine.RequestIdCollection(String, Int) =
     state_machine.request_ids_new()
   let collection =
     state_machine.send_request_to_collection(
-      machine.data,
+      machine.ref,
       GetCounter,
       "a",
       collection,
     )
   let collection =
     state_machine.send_request_to_collection(
-      machine.data,
+      machine.ref,
       GetCounter,
       "b",
       collection,
@@ -741,20 +752,20 @@ pub fn request_ids_to_list_contains_all_entries_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ReqRunning, initial_data: 0)
     |> state_machine.on_event(reqid_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let collection: state_machine.RequestIdCollection(String, Int) =
     state_machine.request_ids_new()
   let collection =
     state_machine.send_request_to_collection(
-      machine.data,
+      machine.ref,
       GetCounter,
       "x",
       collection,
     )
   let collection =
     state_machine.send_request_to_collection(
-      machine.data,
+      machine.ref,
       GetCounter,
       "y",
       collection,
@@ -781,10 +792,10 @@ pub fn request_ids_add_manually_adds_to_collection_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ReqRunning, initial_data: 7)
     |> state_machine.on_event(reqid_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let request: state_machine.RequestId(Int) =
-    state_machine.send_request(machine.data, GetCounter)
+    state_machine.send_request(machine.ref, GetCounter)
   let collection: state_machine.RequestIdCollection(String, Int) =
     state_machine.request_ids_new()
   let collection =
@@ -832,7 +843,7 @@ pub fn stop_and_reply_sends_reply_before_stopping_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: SarRunning, initial_data: Nil)
     |> state_machine.on_event(stop_and_reply_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let monitor = process.monitor(machine.pid)
   let sel =
@@ -840,7 +851,7 @@ pub fn stop_and_reply_sends_reply_before_stopping_test() {
     |> process.select_specific_monitor(monitor, fn(d) { d })
 
   let req: state_machine.RequestId(String) =
-    state_machine.send_request(machine.data, SarGetAndStop)
+    state_machine.send_request(machine.ref, SarGetAndStop)
   let assert Ok(reply) = state_machine.receive_response(req, 1000)
   reply |> should.equal("bye")
 
@@ -877,9 +888,9 @@ fn hibernate_after_handler(
 pub fn hibernate_after_puts_idle_process_into_hibernation_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: HibIdle, initial_data: Nil)
-    |> state_machine.hibernate_after(10)
+    |> state_machine.with_hibernate_after(start_options.Milliseconds(10))
     |> state_machine.on_event(hibernate_after_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   // Wait long enough for the idle timer to fire. When hibernating, the
   // process's current_function is gen_statem:loop_hibernate/3.
@@ -892,7 +903,7 @@ pub fn hibernate_after_puts_idle_process_into_hibernation_test() {
 
   // Sending a message wakes the process; the handler still runs.
   let reply_sub = process.new_subject()
-  process.send(machine.data, HibPing(reply_with: reply_sub))
+  process.send(subject_of(machine), HibPing(reply_with: reply_sub))
   let assert Ok(reply) = process.receive(reply_sub, 1000)
   reply |> should.equal("pong")
 }
@@ -902,7 +913,7 @@ pub fn machine_without_hibernate_after_does_not_hibernate_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: HibIdle, initial_data: Nil)
     |> state_machine.on_event(hibernate_after_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   process.sleep(50)
 
@@ -953,7 +964,7 @@ pub fn on_format_status_overrides_data_in_status_report_test() {
       }
       state_machine.Status(..status, data: FmtRedacted(label: label))
     })
-    |> state_machine.start
+    |> state_machine.start_link
 
   let status = sys_get_status(machine.pid)
   string.inspect(status)
@@ -965,7 +976,7 @@ pub fn machine_without_format_status_still_appears_in_status_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: FmtIdle, initial_data: FmtSecret(value: 0))
     |> state_machine.on_event(fmt_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   // Should not crash; sys:get_status returns a non-empty term.
   let _ = sys_get_status(machine.pid)
@@ -1010,14 +1021,14 @@ pub fn stop_server_terminates_machine_with_normal_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ClientRunning, initial_data: 0)
     |> state_machine.on_event(client_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let monitor = process.monitor(machine.pid)
   let sel =
     process.new_selector()
     |> process.select_specific_monitor(monitor, fn(d) { d })
 
-  state_machine.stop_server(machine.data)
+  state_machine.stop_server(subject_of(machine))
 
   let assert Ok(down) = process.selector_receive(sel, 1000)
   down.reason |> should.equal(process.Normal)
@@ -1032,7 +1043,7 @@ pub fn stop_server_with_custom_reason_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ClientRunning, initial_data: 0)
     |> state_machine.on_event(client_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let monitor = process.monitor(machine.pid)
   let sel =
@@ -1042,7 +1053,7 @@ pub fn stop_server_with_custom_reason_test() {
   let reason = process.Abnormal(dynamic.string("shutdown_requested"))
   let _ =
     process.spawn_unlinked(fn() {
-      state_machine.stop_server_with(machine.data, reason, 1000)
+      state_machine.stop_server_with(subject_of(machine), reason, 1000)
     })
 
   // The exact reason round-tripping through gleam_erlang's monitor decoder
@@ -1060,11 +1071,11 @@ pub fn send_reply_from_external_process_completes_call_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ClientRunning, initial_data: 0)
     |> state_machine.on_event(client_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let stash: process.Subject(state_machine.From(Int)) = process.new_subject()
   let req: state_machine.RequestId(Int) =
-    state_machine.send_request(machine.data, CliAsk(stash))
+    state_machine.send_request(machine.ref, CliAsk(stash))
 
   let assert Ok(from) = process.receive(stash, 1000)
   state_machine.send_reply(from, 123)
@@ -1077,14 +1088,14 @@ pub fn send_replies_completes_multiple_calls_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ClientRunning, initial_data: 0)
     |> state_machine.on_event(client_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let stash: process.Subject(state_machine.From(Int)) = process.new_subject()
 
   let req1: state_machine.RequestId(Int) =
-    state_machine.send_request(machine.data, CliAsk(stash))
+    state_machine.send_request(machine.ref, CliAsk(stash))
   let req2: state_machine.RequestId(Int) =
-    state_machine.send_request(machine.data, CliAsk(stash))
+    state_machine.send_request(machine.ref, CliAsk(stash))
 
   let assert Ok(from1) = process.receive(stash, 1000)
   let assert Ok(from2) = process.receive(stash, 1000)
@@ -1101,10 +1112,10 @@ pub fn wait_response_returns_reply_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ClientRunning, initial_data: 99)
     |> state_machine.on_event(client_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let req: state_machine.RequestId(Int) =
-    state_machine.send_request(machine.data, CliGet)
+    state_machine.send_request(machine.ref, CliGet)
   let assert Ok(value) = state_machine.wait_response(req)
   value |> should.equal(99)
 }
@@ -1113,10 +1124,10 @@ pub fn wait_response_timeout_yields_receive_timeout_when_no_reply_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ClientRunning, initial_data: 0)
     |> state_machine.on_event(client_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let req: state_machine.RequestId(Int) =
-    state_machine.send_request(machine.data, CliNoReply)
+    state_machine.send_request(machine.ref, CliNoReply)
 
   state_machine.wait_response_timeout(req, 50)
   |> should.equal(Error(state_machine.ReceiveTimeout))
@@ -1126,10 +1137,10 @@ pub fn check_response_returns_none_for_unrelated_message_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ClientRunning, initial_data: 0)
     |> state_machine.on_event(client_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let req: state_machine.RequestId(Int) =
-    state_machine.send_request(machine.data, CliGet)
+    state_machine.send_request(machine.ref, CliGet)
 
   // An int dynamic is not a gen_statem reply tuple.
   let unrelated = dynamic.int(42)
@@ -1146,10 +1157,10 @@ pub fn check_response_returns_some_for_matching_reply_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ClientRunning, initial_data: 11)
     |> state_machine.on_event(client_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let req: state_machine.RequestId(Int) =
-    state_machine.send_request(machine.data, CliGet)
+    state_machine.send_request(machine.ref, CliGet)
 
   let selector =
     process.new_selector()
@@ -1169,10 +1180,10 @@ pub fn receive_response_blocking_returns_reply_test() {
   let assert Ok(machine) =
     state_machine.new(initial_state: ClientRunning, initial_data: 7)
     |> state_machine.on_event(client_handler)
-    |> state_machine.start
+    |> state_machine.start_link
 
   let req: state_machine.RequestId(Int) =
-    state_machine.send_request(machine.data, CliGet)
+    state_machine.send_request(machine.ref, CliGet)
   let assert Ok(value) = state_machine.receive_response_blocking(req)
   value |> should.equal(7)
 }

--- a/test/eparch_test_helpers.erl
+++ b/test/eparch_test_helpers.erl
@@ -1,0 +1,22 @@
+-module(eparch_test_helpers).
+-moduledoc """
+Test-only helpers used by `start_options_test.gleam`. Pure encoding glue:
+build the Erlang-shape values that Gleam cannot construct through its
+own type system (e.g. the raw `{global, Name}` tuple consumed by
+`gen_statem:cast/2`).
+""".
+
+-export([encode_global_target/1, encode_atom_as_term/1, encode_ping/1]).
+
+-doc "Build the `{global, Name}` server-ref tuple consumed by `gen_statem`.".
+encode_global_target(Name) -> {global, Name}.
+
+-doc "Pass an atom through as an opaque dynamic term.".
+encode_atom_as_term(Atom) -> Atom.
+
+-doc """
+Build a Gleam `Msg::Ping(reply_with: subject)` value at the Erlang level.
+Gleam encodes the `Ping` variant as the tagged tuple `{ping, Subject}`.
+""".
+encode_ping(ReplySubject) ->
+    {ping, ReplySubject}.

--- a/test/event_manager_test.gleam
+++ b/test/event_manager_test.gleam
@@ -6,6 +6,7 @@
 ////
 
 import eparch/event_manager
+import eparch/start_options
 import gleam/dynamic.{type Dynamic}
 import gleam/erlang/process
 import gleam/int
@@ -400,9 +401,9 @@ pub fn start_monitor_already_started_returns_error_test() {
 pub fn start_monitor_accepts_option_passthrough_test() {
   let options =
     event_manager.new_start_options()
-    |> event_manager.with_timeout(event_manager.Milliseconds(5000))
+    |> event_manager.with_timeout(start_options.Milliseconds(5000))
     |> event_manager.with_spawn_options([
-      event_manager.SpawnPriority(event_manager.PriorityNormal),
+      start_options.SpawnPriority(start_options.PriorityNormal),
     ])
 
   let assert Ok(monitored) = event_manager.start_monitor(options)

--- a/test/start_options_test.gleam
+++ b/test/start_options_test.gleam
@@ -1,0 +1,299 @@
+////
+//// Coverage for the new start surface introduced in `eparch/state_machine`:
+//// `start_link`/`start`/`start_monitor`, `Local`/`Global`/`Via` registration,
+//// `ServerRef` conversions, and the `with_debug`/`with_spawn_options`/
+//// `with_hibernate_after` builder setters.
+////
+
+import eparch/start_options
+import eparch/state_machine
+import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode
+import gleam/erlang/atom
+import gleam/erlang/process
+import gleeunit/should
+
+@external(erlang, "erlang", "process_info")
+fn process_info(pid: process.Pid, key: atom.Atom) -> Dynamic
+
+@external(erlang, "global", "whereis_name")
+fn global_whereis(name: atom.Atom) -> Dynamic
+
+@external(erlang, "gen_statem", "cast")
+fn gen_statem_cast(server: Dynamic, msg: Dynamic) -> atom.Atom
+
+// ---------------------------------------------------------------------------
+// Shared event type used across tests in this file.
+// ---------------------------------------------------------------------------
+
+type Msg {
+  Ping(reply_with: process.Subject(String))
+  Crash
+}
+
+type State {
+  Running
+}
+
+fn handler(
+  event: state_machine.Event(State, Msg, Nil),
+  _state: State,
+  data: Nil,
+) -> state_machine.Step(State, Nil, Msg, Nil) {
+  case event {
+    state_machine.Info(Ping(reply_with:)) -> {
+      process.send(reply_with, "pong")
+      state_machine.keep_state(data, [])
+    }
+    state_machine.Cast(Ping(reply_with:)) -> {
+      process.send(reply_with, "pong-cast")
+      state_machine.keep_state(data, [])
+    }
+    state_machine.Cast(Crash) ->
+      state_machine.stop(process.Abnormal(dynamic.string("boom")))
+    state_machine.Info(Crash) ->
+      state_machine.stop(process.Abnormal(dynamic.string("boom")))
+    _ -> state_machine.keep_state(data, [])
+  }
+}
+
+fn builder() -> state_machine.Builder(State, Nil, Msg, Nil) {
+  state_machine.new(initial_state: Running, initial_data: Nil)
+  |> state_machine.on_event(handler)
+}
+
+// ---------------------------------------------------------------------------
+// start_link with Local name: ref_to_subject succeeds and process.named/1
+// resolves the same pid.
+// ---------------------------------------------------------------------------
+
+pub fn start_link_local_resolves_via_process_named_test() {
+  let name = process.new_name("eparch_test_local")
+  let assert Ok(machine) =
+    builder()
+    |> state_machine.named(state_machine.Local(name))
+    |> state_machine.start_link
+
+  let assert Ok(subject) = state_machine.ref_to_subject(machine.ref)
+  let assert Ok(named_pid) = process.named(name)
+  named_pid |> should.equal(machine.pid)
+
+  let reply = process.new_subject()
+  process.send(subject, Ping(reply))
+  let assert Ok(payload) = process.receive(reply, 1000)
+  payload |> should.equal("pong")
+}
+
+// ---------------------------------------------------------------------------
+// start (unlinked): the parent survives when the child crashes abnormally.
+// ---------------------------------------------------------------------------
+
+pub fn start_unlinked_does_not_propagate_crash_test() {
+  let assert Ok(machine) = builder() |> state_machine.start
+
+  let monitor = process.monitor(machine.pid)
+  let selector =
+    process.new_selector()
+    |> process.select_specific_monitor(monitor, fn(down) { down })
+
+  // Send Crash via cast: handler returns Stop(Abnormal). With no link, the
+  // parent test process must keep running.
+  state_machine.cast(machine.ref, Crash)
+  let assert Ok(_down) = process.selector_receive(selector, 1000)
+
+  // The fact that we got here at all is the test: the parent did not exit.
+  process.self() |> should.not_equal(machine.pid)
+}
+
+// ---------------------------------------------------------------------------
+// start_monitor: returns an atomic monitor that fires when the child dies.
+// ---------------------------------------------------------------------------
+
+pub fn start_monitor_delivers_down_test() {
+  let assert Ok(monitored) = builder() |> state_machine.start_monitor
+
+  let selector =
+    process.new_selector()
+    |> process.select_specific_monitor(monitored.monitor, fn(down) { down })
+
+  // Trigger an abnormal stop via cast (the link from start_monitor would
+  // otherwise propagate to the test process, but gleeunit isolates each
+  // test in its own process so the worst case is a single test failure).
+  process.unlink(monitored.pid)
+  state_machine.cast(monitored.ref, Crash)
+
+  let assert Ok(down) = process.selector_receive(selector, 1000)
+  case down {
+    process.ProcessDown(pid:, ..) -> pid |> should.equal(monitored.pid)
+    process.PortDown(..) -> panic as "expected ProcessDown"
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Global registration: gen_statem:cast({global, _}, _) reaches the process,
+// and ref_to_subject reports Error since there is no associated Subject.
+// ---------------------------------------------------------------------------
+
+pub fn global_named_start_routes_through_global_module_test() {
+  let global_name = atom.create("eparch_test_global_machine")
+  let assert Ok(machine) =
+    builder()
+    |> state_machine.named(state_machine.Global(global_name))
+    |> state_machine.start_link
+
+  // The global registry knows about the process.
+  global_whereis(global_name)
+  |> decode.run(decode.dynamic)
+  |> should.be_ok
+
+  // No Subject is exposed for global-registered servers.
+  state_machine.ref_to_subject(machine.ref) |> should.equal(Error(Nil))
+
+  // gen_statem:cast on the global tuple delivers a Cast event.
+  let reply = process.new_subject()
+  let global_target = encode_global_target(global_name)
+  let cast_msg = encode_ping(reply)
+  let _ = gen_statem_cast(global_target, cast_msg)
+
+  let assert Ok(payload) = process.receive(reply, 1000)
+  payload |> should.equal("pong-cast")
+}
+
+@external(erlang, "eparch_test_helpers", "encode_global_target")
+fn encode_global_target(name: atom.Atom) -> Dynamic
+
+@external(erlang, "eparch_test_helpers", "encode_ping")
+fn encode_ping(reply: process.Subject(String)) -> Dynamic
+
+// ---------------------------------------------------------------------------
+// Via registration: the `global` module itself implements the `via` registry
+// API (register_name/2, unregister_name/1, whereis_name/1, send/2), so we can
+// use it as a stand-in via-target without authoring a custom registry.
+// ---------------------------------------------------------------------------
+
+pub fn via_global_routes_through_via_target_test() {
+  let via_name = atom.create("eparch_test_via_machine")
+  let assert Ok(machine) =
+    builder()
+    |> state_machine.named(state_machine.Via(
+      module: atom.create("global"),
+      name: encode_atom_as_term(via_name),
+    ))
+    |> state_machine.start_link
+
+  state_machine.ref_to_subject(machine.ref) |> should.equal(Error(Nil))
+
+  let reply = process.new_subject()
+  state_machine.cast(machine.ref, Ping(reply))
+  let assert Ok(payload) = process.receive(reply, 1000)
+  payload |> should.equal("pong-cast")
+
+  machine.pid |> should.not_equal(process.self())
+}
+
+@external(erlang, "eparch_test_helpers", "encode_atom_as_term")
+fn encode_atom_as_term(value: atom.Atom) -> Dynamic
+
+// ---------------------------------------------------------------------------
+// with_spawn_options: the SpawnPriority is reflected in process_info.
+// ---------------------------------------------------------------------------
+
+pub fn with_spawn_options_sets_process_priority_test() {
+  let assert Ok(machine) =
+    builder()
+    |> state_machine.with_spawn_options([
+      start_options.SpawnPriority(start_options.PriorityHigh),
+    ])
+    |> state_machine.start_link
+
+  let info = process_info(machine.pid, atom.create("priority"))
+  decoded_priority_atom(info) |> should.equal(atom.create("high"))
+}
+
+fn decoded_priority_atom(info: Dynamic) -> atom.Atom {
+  let decoder = {
+    use _ <- decode.field(0, decode.dynamic)
+    use value <- decode.field(1, atom.decoder())
+    decode.success(value)
+  }
+  let assert Ok(value) = decode.run(info, decoder)
+  value
+}
+
+// ---------------------------------------------------------------------------
+// with_debug: starting with debug flags is a smoke test — the only useful
+// observation is that the process starts and serves messages normally.
+// ---------------------------------------------------------------------------
+
+pub fn with_debug_accepts_log_flag_test() {
+  let assert Ok(machine) =
+    builder()
+    |> state_machine.with_debug([start_options.DebugLog])
+    |> state_machine.start_link
+
+  let assert Ok(subject) = state_machine.ref_to_subject(machine.ref)
+  let reply = process.new_subject()
+  process.send(subject, Ping(reply))
+  let assert Ok(payload) = process.receive(reply, 1000)
+  payload |> should.equal("pong")
+}
+
+// ---------------------------------------------------------------------------
+// with_hibernate_after: after the configured idle window, the process is in
+// `erlang:hibernate/3` waiting for the next message.
+// ---------------------------------------------------------------------------
+
+pub fn with_hibernate_after_accepts_option_test() {
+  // Smoke test for the with_hibernate_after wiring. The actual hibernation
+  // behaviour is hard to assert reliably from the outside (process_info
+  // does not always reflect the internal hibernate transition), so we
+  // verify only that the option is accepted by the FFI and the process
+  // continues to handle messages.
+  let assert Ok(machine) =
+    builder()
+    |> state_machine.with_hibernate_after(start_options.Milliseconds(20))
+    |> state_machine.start_link
+
+  let assert Ok(subject) = state_machine.ref_to_subject(machine.ref)
+  let reply = process.new_subject()
+  process.send(subject, Ping(reply))
+  let assert Ok(payload) = process.receive(reply, 1000)
+  payload |> should.equal("pong")
+
+  process.sleep(80)
+
+  // Wake the process: must still respond after the hibernate window.
+  let reply2 = process.new_subject()
+  process.send(subject, Ping(reply2))
+  let assert Ok(payload2) = process.receive(reply2, 1000)
+  payload2 |> should.equal("pong")
+}
+
+// ---------------------------------------------------------------------------
+// ref_from_subject and ref_from_pid round-trip with cast.
+// ---------------------------------------------------------------------------
+
+pub fn ref_from_subject_round_trip_test() {
+  let assert Ok(machine) = builder() |> state_machine.start_link
+  let assert Ok(subject) = state_machine.ref_to_subject(machine.ref)
+
+  let wrapped = state_machine.ref_from_subject(subject)
+  let reply = process.new_subject()
+  state_machine.cast(wrapped, Ping(reply))
+
+  let assert Ok(payload) = process.receive(reply, 1000)
+  payload |> should.equal("pong-cast")
+}
+
+pub fn ref_from_pid_supports_cast_test() {
+  let assert Ok(machine) = builder() |> state_machine.start_link
+
+  let from_pid = state_machine.ref_from_pid(machine.pid)
+  // ref_from_pid produces a ref with no associated Subject.
+  state_machine.ref_to_subject(from_pid) |> should.equal(Error(Nil))
+
+  let reply = process.new_subject()
+  state_machine.cast(from_pid, Ping(reply))
+  let assert Ok(payload) = process.receive(reply, 1000)
+  payload |> should.equal("pong-cast")
+}


### PR DESCRIPTION
## Description

The bigger diff is mostly because I moved common types to a "shared" module, so this affects both the `state_machine` and `event_machine` codebases.

- shared `Timeout`/`DebugFlag`/`SpawnOption`/`Priority`/`MessageQueueMode` types.
- shared encoders for those types.
- coverage of `start_link`/`start`/`start_monitor`, `Local`/`Global`/`Via`, `ServerRef` conversions, and option setters.
- Erlang shape helpers used by the new test file.

## Related Issue

<!-- Link to the issue this PR addresses, if any. -->
<!-- Use "Closes #123" to auto-close the issue on merge. -->

- Closes #31 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update
- [x] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated (if applicable)
- [x] `gleam format` run
