### PR TITLE
feat: add named event managers

### DIFF
--- a/src/eparch/event_manager.gleam
+++ b/src/eparch/event_manager.gleam
@@ -17,7 +17,7 @@
 ////
 //// type MyEvent { LogLine(String) | Flush(process.Subject(Nil)) }
 ////
-//// case event_manager.start() {
+//// case event_manager.start_link(event_manager.new_start_options()) {
 ////   Ok(manager) -> {
 ////     let handler =
 ////       event_manager.new_handler(0, fn(event, count) {
@@ -41,6 +41,7 @@ import eparch/start_options.{
   type DebugFlag, type SpawnOption, type Timeout, Infinity,
 }
 import gleam/dynamic.{type Dynamic}
+import gleam/erlang/atom.{type Atom}
 import gleam/erlang/process.{type Monitor, type Name, type Pid}
 import gleam/option.{type Option, None, Some}
 
@@ -68,12 +69,27 @@ pub type StartError {
   StartFailed(reason: String)
 }
 
-/// Options for `start_monitor`. Build a value with `new_start_options()` and
-/// extend it using the `with_*` setter functions.
+/// A name under which an event manager can be registered.
+///
+/// Mirrors `gen_event:emgr_name/0`:
+/// - `Local(name)` registers locally with `erlang:register/2` and gives back
+///   a `process.Name(event)` you can turn into a `Subject(event)`.
+/// - `Global(name)` registers across nodes via the `global` module.
+/// - `Via(module, name)` dispatches registration through any module
+///   implementing the `via` registry behaviour (e.g. `gproc`, `syn`).
+///
+pub type ServerName(event) {
+  Local(name: Name(event))
+  Global(name: Atom)
+  Via(module: Atom, name: Dynamic)
+}
+
+/// Options for `start_link`, `start`, and `start_monitor`. Build a value with
+/// `new_start_options()` and extend it using the `with_*` setter functions.
 ///
 pub opaque type StartOptions(event) {
   StartOptions(
-    name: Option(Name(event)),
+    name: Option(ServerName(event)),
     timeout: Timeout,
     hibernate_after: Timeout,
     debug: List(DebugFlag),
@@ -134,9 +150,10 @@ pub type HandlerRef(request, reply)
 
 /// An opaque reference to a running event manager process.
 ///
-/// Values of this type are produced by `start` (directly) and `start_monitor`
-/// (as the `manager` field of the returned `MonitoredManager`). Pass them to
-/// `notify`, `sync_notify`, `add_handler`, etc.
+/// Values of this type are produced by `start_link` and `start` (directly)
+/// and by `start_monitor` (as the `manager` field of the returned
+/// `MonitoredManager`). Pass them to `notify`, `sync_notify`, `add_handler`,
+/// etc.
 ///
 pub type Manager(event)
 
@@ -250,13 +267,16 @@ pub fn new_start_options() -> StartOptions(event) {
   )
 }
 
-/// Register the manager under a local name. Gives callers a
-/// `process.Name(event)` they can turn into a `Subject` or look up with
-/// `process.named/1`.
+/// Register the manager under a name when it starts.
+///
+/// Pass `Local(name)` for the common local-atom registration (the only form
+/// compatible with a `process.Subject`), `Global(name)` for cluster-wide
+/// registration via the `global` module, or `Via(module, term)` for a
+/// custom registry such as `gproc` or `syn`.
 ///
 pub fn with_name(
   options: StartOptions(event),
-  name: Name(event),
+  name: ServerName(event),
 ) -> StartOptions(event) {
   StartOptions(..options, name: Some(name))
 }
@@ -305,10 +325,14 @@ pub fn with_spawn_options(
 
 /// Start an event manager process linked to the caller.
 ///
+/// Maps to `gen_event:start_link/1,2`. Use `with_name` on the options to
+/// register the manager under a `Local`, `Global`, or `Via` name; otherwise
+/// the manager is started anonymously.
+///
 /// ## Example
 ///
 /// ```gleam
-/// case event_manager.start() {
+/// case event_manager.start_link(event_manager.new_start_options()) {
 ///   Ok(manager) -> {
 ///     // ... use manager ...
 ///     event_manager.stop(manager)
@@ -317,20 +341,49 @@ pub fn with_spawn_options(
 /// }
 /// ```
 ///
-pub fn start() -> Result(Manager(event), StartError) {
-  do_start()
+/// ## Example: registered under a local name
+///
+/// ```gleam
+/// let name = process.new_name("my_event_manager")
+/// let options =
+///   event_manager.new_start_options()
+///   |> event_manager.with_name(event_manager.Local(name))
+/// let assert Ok(manager) = event_manager.start_link(options)
+/// ```
+///
+pub fn start_link(
+  options: StartOptions(event),
+) -> Result(Manager(event), StartError) {
+  do_start_link(options)
 }
 
-@external(erlang, "event_manager_ffi", "do_start")
-fn do_start() -> Result(Manager(event), StartError)
+@external(erlang, "event_manager_ffi", "do_start_link")
+fn do_start_link(
+  options: StartOptions(event),
+) -> Result(Manager(event), StartError)
+
+/// Start an event manager process without linking it to the caller.
+///
+/// Maps to `gen_event:start/1,2`. Useful when the parent does not want
+/// link-based crash propagation, e.g. when the parent will install its own
+/// monitor or hand the manager to a custom supervisor.
+///
+pub fn start(options: StartOptions(event)) -> Result(Manager(event), StartError) {
+  do_start_no_link(options)
+}
+
+@external(erlang, "event_manager_ffi", "do_start_no_link")
+fn do_start_no_link(
+  options: StartOptions(event),
+) -> Result(Manager(event), StartError)
 
 /// Start an event manager linked to the caller and atomically return a
 /// monitor for it.
 ///
-/// Equivalent to calling `start()` followed by `process.monitor(manager_pid)`,
-/// but without the race window between the two calls. The returned
-/// `MonitoredManager` carries both the `Manager` and a `process.Monitor` you
-/// can select on. Since OTP 23.0.
+/// Equivalent to calling `start_link(options)` followed by
+/// `process.monitor(manager_pid)`, but without the race window between the
+/// two calls. The returned `MonitoredManager` carries both the `Manager` and
+/// a `process.Monitor` you can select on. Since OTP 23.0.
 ///
 /// ## Example
 ///

--- a/src/event_manager_ffi.erl
+++ b/src/event_manager_ffi.erl
@@ -19,7 +19,8 @@ every installed instance distinguishable.
 
 %% Public API (called from Gleam via @external)
 -export([
-    do_start/0,
+    do_start_link/1,
+    do_start_no_link/1,
     do_start_monitor/1,
     do_stop/1,
     do_manager_pid/1,
@@ -71,31 +72,49 @@ every installed instance distinguishable.
 -doc """
 Start a `gen_event` manager linked to the calling process.
 
-Returns a `Manager(event)` value, which at the Erlang level is just 
-the Pid of the manager process.
-""".
-do_start() ->
-    case gen_event:start_link() of
-        {ok, Pid} ->
-            {ok, Pid};
-        {error, {already_started, Pid}} ->
-            {error, {already_started, Pid}};
-        {error, Reason} ->
-            {error, {start_failed, format_reason(Reason)}}
-    end.
-
--doc """
-Start a gen_event manager with an atomic monitor (OTP 23.0+).
-
 The Gleam side passes an opaque `StartOptions` record, encoded at the Erlang
 level as:
 
     {start_options, NameOpt, Timeout, HibernateAfter, DebugFlags, SpawnOpts}
 
-`NameOpt` is `none | {some, Name}`; `Timeout`/`HibernateAfter` are
-`infinity | {milliseconds, Ms}`; the two list fields are empty when unused.
-Returns the `MonitoredManager(manager, monitor)` 3-tuple the Gleam compiler
-expects.
+`NameOpt` is `none | {some, ServerName}` where `ServerName` arrives as the
+canonical gen_event tuple shape: `{local, atom()}`, `{global, atom()}`, or
+`{via, atom(), term()}`. Returns a `Manager(event)` value (a Pid at the
+Erlang level) on success.
+""".
+do_start_link({start_options, NameOpt, Timeout, HibernateAfter, DebugFlags, SpawnOpts}) ->
+    ErlangOpts = build_start_opts(Timeout, HibernateAfter, DebugFlags, SpawnOpts),
+    Result =
+        case NameOpt of
+            none ->
+                gen_event:start_link(ErlangOpts);
+            {some, ServerName} ->
+                gen_event:start_link(ServerName, ErlangOpts)
+        end,
+    convert_start_result(Result).
+
+-doc """
+Start a `gen_event` manager without linking it to the calling process.
+
+Same options encoding as `do_start_link/1`. Useful when the parent will
+install its own monitor or hand the manager to a custom supervisor.
+""".
+do_start_no_link({start_options, NameOpt, Timeout, HibernateAfter, DebugFlags, SpawnOpts}) ->
+    ErlangOpts = build_start_opts(Timeout, HibernateAfter, DebugFlags, SpawnOpts),
+    Result =
+        case NameOpt of
+            none ->
+                gen_event:start(ErlangOpts);
+            {some, ServerName} ->
+                gen_event:start(ServerName, ErlangOpts)
+        end,
+    convert_start_result(Result).
+
+-doc """
+Start a gen_event manager with an atomic monitor (OTP 23.0+).
+
+Same options encoding as `do_start_link/1`. Returns the
+`MonitoredManager(manager, monitor)` 3-tuple the Gleam compiler expects.
 """.
 do_start_monitor({start_options, NameOpt, Timeout, HibernateAfter, DebugFlags, SpawnOpts}) ->
     ErlangOpts = build_start_opts(Timeout, HibernateAfter, DebugFlags, SpawnOpts),
@@ -103,17 +122,24 @@ do_start_monitor({start_options, NameOpt, Timeout, HibernateAfter, DebugFlags, S
         case NameOpt of
             none ->
                 gen_event:start_monitor(ErlangOpts);
-            {some, Name} ->
-                gen_event:start_monitor({local, Name}, ErlangOpts)
+            {some, ServerName} ->
+                gen_event:start_monitor(ServerName, ErlangOpts)
         end,
-    case Result of
-        {ok, {Pid, MonitorRef}} ->
-            {ok, {monitored_manager, Pid, MonitorRef}};
-        {error, {already_started, Pid}} ->
-            {error, {already_started, Pid}};
-        {error, Reason} ->
-            {error, {start_failed, format_reason(Reason)}}
-    end.
+    convert_monitor_result(Result).
+
+convert_start_result({ok, Pid}) ->
+    {ok, Pid};
+convert_start_result({error, {already_started, Pid}}) ->
+    {error, {already_started, Pid}};
+convert_start_result({error, Reason}) ->
+    {error, {start_failed, format_reason(Reason)}}.
+
+convert_monitor_result({ok, {Pid, MonitorRef}}) ->
+    {ok, {monitored_manager, Pid, MonitorRef}};
+convert_monitor_result({error, {already_started, Pid}}) ->
+    {error, {already_started, Pid}};
+convert_monitor_result({error, Reason}) ->
+    {error, {start_failed, format_reason(Reason)}}.
 
 build_start_opts(Timeout, HibernateAfter, DebugFlags, SpawnOpts) ->
     [

--- a/test/event_manager_test.gleam
+++ b/test/event_manager_test.gleam
@@ -22,8 +22,58 @@ fn sys_get_status(pid: process.Pid) -> Dynamic
 // ---------------------------------------------------------------------------
 
 pub fn start_and_stop_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
   event_manager.stop(mgr)
+}
+
+pub fn start_link_with_local_name_registers_process_test() {
+  let name = process.new_name("eparch_event_manager_start_link_test_")
+  let options =
+    event_manager.new_start_options()
+    |> event_manager.with_name(event_manager.Local(name))
+
+  let assert Ok(mgr) = event_manager.start_link(options)
+
+  let assert Ok(registered_pid) = process.named(name)
+  registered_pid |> should.equal(event_manager.manager_pid(mgr))
+
+  event_manager.stop(mgr)
+}
+
+pub fn start_link_already_started_returns_error_test() {
+  let name = process.new_name("eparch_event_manager_start_link_dup_test_")
+  let options =
+    event_manager.new_start_options()
+    |> event_manager.with_name(event_manager.Local(name))
+
+  let assert Ok(mgr) = event_manager.start_link(options)
+  let first_pid = event_manager.manager_pid(mgr)
+
+  let assert Error(event_manager.AlreadyStarted(reported_pid)) =
+    event_manager.start_link(options)
+  reported_pid |> should.equal(first_pid)
+
+  event_manager.stop(mgr)
+}
+
+pub fn start_unlinked_does_not_propagate_crash_test() {
+  let assert Ok(mgr) = event_manager.start(event_manager.new_start_options())
+  let mgr_pid = event_manager.manager_pid(mgr)
+
+  let monitor = process.monitor(mgr_pid)
+  let selector =
+    process.new_selector()
+    |> process.select_specific_monitor(monitor, fn(down) { down })
+
+  // Kill the manager untrappably. With no link, the test process is
+  // unaffected and continues past selector_receive.
+  process.kill(mgr_pid)
+  let assert Ok(_down) = process.selector_receive(selector, 1000)
+
+  // Reaching this point proves the test process did not exit alongside the
+  // manager, i.e. start/1 did not establish a link.
+  process.self() |> should.not_equal(mgr_pid)
 }
 
 // ---------------------------------------------------------------------------
@@ -38,7 +88,8 @@ type NotifyMsg {
 }
 
 pub fn notify_delivers_event_to_handler_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let handler =
     event_manager.new_handler(Nil, fn(event, state) {
@@ -73,7 +124,8 @@ type SyncMsg {
 }
 
 pub fn sync_notify_blocks_until_handler_processes_event_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let handler =
     event_manager.new_handler(Nil, fn(event, state) {
@@ -108,7 +160,8 @@ type MultiMsg {
 }
 
 pub fn multiple_handlers_both_receive_broadcast_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let make_handler = fn(tag: String) {
     event_manager.new_handler(Nil, fn(event, state) {
@@ -149,7 +202,8 @@ type RemoveSelfMsg {
 }
 
 pub fn handler_removes_itself_via_remove_step_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let counter_handler =
     event_manager.new_handler(Nil, fn(event, _state) {
@@ -179,7 +233,8 @@ pub fn handler_removes_itself_via_remove_step_test() {
 // ---------------------------------------------------------------------------
 
 pub fn explicit_remove_handler_removes_by_ref_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let h =
     event_manager.new_handler(Nil, fn(_event, state) {
@@ -203,7 +258,8 @@ pub fn explicit_remove_handler_removes_by_ref_test() {
 // ---------------------------------------------------------------------------
 
 pub fn which_handlers_reflects_add_and_remove_operations_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let make_h = fn() {
     event_manager.new_handler(Nil, fn(_event, state) {
@@ -243,7 +299,8 @@ type TerminateMsg {
 }
 
 pub fn on_terminate_called_when_handler_removed_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let reply_sub = process.new_subject()
 
@@ -275,7 +332,8 @@ pub fn on_terminate_called_when_handler_removed_test() {
 // ---------------------------------------------------------------------------
 
 pub fn on_format_status_overrides_state_in_status_report_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let h =
     event_manager.new_handler(42, fn(_event, state) {
@@ -294,7 +352,8 @@ pub fn on_format_status_overrides_state_in_status_report_test() {
 }
 
 pub fn handler_without_format_status_still_appears_in_status_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let h =
     event_manager.new_handler(Nil, fn(_event, state) {
@@ -366,7 +425,7 @@ pub fn start_monitor_with_name_registers_process_test() {
   let name = process.new_name("eparch_event_manager_test_")
   let options =
     event_manager.new_start_options()
-    |> event_manager.with_name(name)
+    |> event_manager.with_name(event_manager.Local(name))
 
   let assert Ok(monitored) = event_manager.start_monitor(options)
 
@@ -386,7 +445,7 @@ pub fn start_monitor_already_started_returns_error_test() {
   let name = process.new_name("eparch_event_manager_dup_test_")
   let options =
     event_manager.new_start_options()
-    |> event_manager.with_name(name)
+    |> event_manager.with_name(event_manager.Local(name))
 
   let assert Ok(monitored) = event_manager.start_monitor(options)
   let first_pid = event_manager.manager_pid(monitored.manager)
@@ -433,7 +492,8 @@ type CallMsg {
 }
 
 pub fn send_request_returns_reply_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let handler =
     event_manager.new_handler(0, fn(event, count) {
@@ -460,7 +520,8 @@ pub fn send_request_returns_reply_test() {
 }
 
 pub fn send_request_sees_latest_handler_state_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let handler =
     event_manager.new_handler(0, fn(event, count) {
@@ -490,7 +551,8 @@ pub fn send_request_sees_latest_handler_state_test() {
 }
 
 pub fn wait_response_returns_same_reply_as_receive_response_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let handler =
     event_manager.new_handler(42, fn(_event, state) {
@@ -509,7 +571,8 @@ pub fn wait_response_returns_same_reply_as_receive_response_test() {
 }
 
 pub fn check_response_returns_check_no_reply_for_unrelated_message_test() {
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let handler =
     event_manager.new_handler(0, fn(_event, state) {
@@ -538,7 +601,8 @@ pub fn check_response_returns_check_got_reply_when_message_matches_test() {
   // tests) so that the select_other catch-all below doesn't capture them.
   process.flush_messages()
 
-  let assert Ok(mgr) = event_manager.start()
+  let assert Ok(mgr) =
+    event_manager.start_link(event_manager.new_start_options())
 
   let handler =
     event_manager.new_handler(7, fn(_event, state) {


### PR DESCRIPTION
## Description

The event_manager wrapper now has the named/monitored manager start API the issue called for.

## Related Issue

<!-- Link to the issue this PR addresses, if any. -->
<!-- Use "Closes #123" to auto-close the issue on merge. -->

- Closes #24 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `gleam format` run
