### PR TITLE
ci: fix gleam publish pipeline, set correct ENVAR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,6 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Publish to Hex
-        run: nix develop --impure --command gleam publish --yes
+        run: nix develop --impure --command gleam publish -y
         env:
-          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+          HEXPM_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
## Description

We were using the [wrong envar name](https://github.com/gleam-lang/gleam/issues/2844).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (if applicable)
- [ ] `gleam format` run
